### PR TITLE
Fix for 'Cannot Add Issue Comment via API: Parameter 'issueIdOrKey' must be of type string or number' (Error #4)

### DIFF
--- a/src/tools/addIssueComment.test.ts
+++ b/src/tools/addIssueComment.test.ts
@@ -54,12 +54,12 @@ describe("addIssueCommentTool", () => {
 
   it("calls backlog.postIssueComments with correct params when using issue ID and notifications", async () => {
     await tool.handler({
-      issueIdOrKey: 1,
+      issueIdOrKey: "1",
       content: "This is a new comment with notifications",
       notifiedUserId: [2, 3]
     });
     
-    expect(mockBacklog.postIssueComments).toHaveBeenCalledWith(1, {
+    expect(mockBacklog.postIssueComments).toHaveBeenCalledWith("1", {
       content: "This is a new comment with notifications",
       notifiedUserId: [2, 3],
       attachmentId: undefined

--- a/src/tools/addIssueComment.ts
+++ b/src/tools/addIssueComment.ts
@@ -5,7 +5,7 @@ import { TranslationHelper } from "../createTranslationHelper.js";
 import { IssueCommentSchema } from "../types/zod/backlogOutputDefinition.js";
 
 const addIssueCommentSchema = buildToolSchema(t => ({
-  issueIdOrKey: z.union([z.string(), z.number()]).describe(t("TOOL_ADD_ISSUE_COMMENT_ISSUE_ID_OR_KEY", "Issue ID or issue key")),
+  issueIdOrKey: z.string().describe(t("TOOL_ADD_ISSUE_COMMENT_ISSUE_ID_OR_KEY", "The issue key (e.g., 'HOME-999') or issue ID (e.g., '1234') as a string")),
   content: z.string().describe(t("TOOL_ADD_ISSUE_COMMENT_CONTENT", "Comment content")),
   notifiedUserId: z.array(z.number()).optional().describe(t("TOOL_ADD_ISSUE_COMMENT_NOTIFIED_USER_ID", "User IDs to notify")),
   attachmentId: z.array(z.number()).optional().describe(t("TOOL_ADD_ISSUE_COMMENT_ATTACHMENT_ID", "Attachment IDs")),


### PR DESCRIPTION
Fix for 'Cannot Add Issue Comment via API: Parameter 'issueIdOrKey' must be of type string or number' (Error #4)
https://github.com/nulab/backlog-mcp-server/issues/4
