### PR TITLE
feat: Add custom fields support for getIssues and countIssues tools

### DIFF
--- a/src/tools/countIssues.test.ts
+++ b/src/tools/countIssues.test.ts
@@ -44,4 +44,55 @@ describe("countIssuesTool", () => {
       createdUntil: "2023-01-31"
     });
   });
+
+  it("calls backlog.getIssuesCount with custom fields", async () => {
+    await tool.handler({
+      projectId: [100],
+      customFields: [
+        { id: 12345, value: "test-value" },
+        { id: 67890, value: 123 }
+      ]
+    });
+    
+    expect(mockBacklog.getIssuesCount).toHaveBeenCalledWith({
+      projectId: [100],
+      customField_12345: "test-value",
+      customField_67890: 123
+    });
+  });
+
+  it("calls backlog.getIssuesCount with custom fields array values", async () => {
+    await tool.handler({
+      customFields: [
+        { id: 11111, value: ["option1", "option2"] }
+      ]
+    });
+    
+    expect(mockBacklog.getIssuesCount).toHaveBeenCalledWith({
+      customField_11111: ["option1", "option2"]
+    });
+  });
+
+  it("calls backlog.getIssuesCount with empty custom fields", async () => {
+    await tool.handler({
+      projectId: [100],
+      customFields: []
+    });
+    
+    expect(mockBacklog.getIssuesCount).toHaveBeenCalledWith({
+      projectId: [100]
+    });
+  });
+
+  it("calls backlog.getIssuesCount without custom fields", async () => {
+    await tool.handler({
+      projectId: [100],
+      statusId: [1]
+    });
+    
+    expect(mockBacklog.getIssuesCount).toHaveBeenCalledWith({
+      projectId: [100],
+      statusId: [1]
+    });
+  });
 });

--- a/src/tools/countIssues.ts
+++ b/src/tools/countIssues.ts
@@ -33,7 +33,7 @@ const countIssuesSchema = buildToolSchema(t => ({
       z.number(),
       z.array(z.string())
     ]).describe(t("TOOL_COUNT_ISSUES_CUSTOM_FIELD_VALUE", "Custom field value"))
-  })).optional().describe(t("TOOL_COUNT_ISSUES_CUSTOM_FIELDS", "Custom field filters")),
+  })).optional().describe(t("TOOL_COUNT_ISSUES_CUSTOM_FIELDS", "Custom fields")),
 }));
 
 export const countIssuesTool = (backlog: Backlog, { t }: TranslationHelper): ToolDefinition<ReturnType<typeof countIssuesSchema>, typeof IssueCountSchema["shape"]> => {
@@ -42,8 +42,7 @@ export const countIssuesTool = (backlog: Backlog, { t }: TranslationHelper): Too
     description: t("TOOL_COUNT_ISSUES_DESCRIPTION", "Returns count of issues"),
     schema: z.object(countIssuesSchema(t)),
     outputSchema: IssueCountSchema,
-    handler: async (params) => {
-      const { customFields, ...rest } = params;
+    handler: async ({ customFields, ...rest }) => {
       return backlog.getIssuesCount({
         ...rest,
         ...customFieldsToPayload(customFields)

--- a/src/tools/countIssues.ts
+++ b/src/tools/countIssues.ts
@@ -3,6 +3,7 @@ import { Backlog } from 'backlog-js';
 import { buildToolSchema, ToolDefinition } from '../types/tool.js';
 import { TranslationHelper } from "../createTranslationHelper.js";
 import { IssueCountSchema } from "../types/zod/backlogOutputDefinition.js";
+import { customFieldsToPayload } from "../backlog/customFields.js";
 
 const countIssuesSchema = buildToolSchema(t => ({
   projectId: z.array(z.number()).optional().describe(t("TOOL_COUNT_ISSUES_PROJECT_ID", "Project IDs")),
@@ -25,6 +26,14 @@ const countIssuesSchema = buildToolSchema(t => ({
   createdUntil: z.string().optional().describe(t("TOOL_COUNT_ISSUES_CREATED_UNTIL", "Created until (yyyy-MM-dd)")),
   updatedSince: z.string().optional().describe(t("TOOL_COUNT_ISSUES_UPDATED_SINCE", "Updated since (yyyy-MM-dd)")),
   updatedUntil: z.string().optional().describe(t("TOOL_COUNT_ISSUES_UPDATED_UNTIL", "Updated until (yyyy-MM-dd)")),
+  customFields: z.array(z.object({
+    id: z.number().describe(t("TOOL_COUNT_ISSUES_CUSTOM_FIELD_ID", "Custom field ID")),
+    value: z.union([
+      z.string(),
+      z.number(),
+      z.array(z.string())
+    ]).describe(t("TOOL_COUNT_ISSUES_CUSTOM_FIELD_VALUE", "Custom field value"))
+  })).optional().describe(t("TOOL_COUNT_ISSUES_CUSTOM_FIELDS", "Custom field filters")),
 }));
 
 export const countIssuesTool = (backlog: Backlog, { t }: TranslationHelper): ToolDefinition<ReturnType<typeof countIssuesSchema>, typeof IssueCountSchema["shape"]> => {
@@ -33,7 +42,12 @@ export const countIssuesTool = (backlog: Backlog, { t }: TranslationHelper): Too
     description: t("TOOL_COUNT_ISSUES_DESCRIPTION", "Returns count of issues"),
     schema: z.object(countIssuesSchema(t)),
     outputSchema: IssueCountSchema,
-    handler: async (params) =>
-      backlog.getIssuesCount(params)
+    handler: async (params) => {
+      const { customFields, ...rest } = params;
+      return backlog.getIssuesCount({
+        ...rest,
+        ...customFieldsToPayload(customFields)
+      });
+    }
   };
 };

--- a/src/tools/getIssues.test.ts
+++ b/src/tools/getIssues.test.ts
@@ -105,4 +105,55 @@ describe("getIssuesTool", () => {
       keyword: "bug"
     });
   });
+
+  it("calls backlog.getIssues with custom fields", async () => {
+    await tool.handler({
+      projectId: [100],
+      customFields: [
+        { id: 12345, value: "test-value" },
+        { id: 67890, value: 123 }
+      ]
+    });
+    
+    expect(mockBacklog.getIssues).toHaveBeenCalledWith({
+      projectId: [100],
+      customField_12345: "test-value",
+      customField_67890: 123
+    });
+  });
+
+  it("calls backlog.getIssues with custom fields array values", async () => {
+    await tool.handler({
+      customFields: [
+        { id: 11111, value: ["option1", "option2"] }
+      ]
+    });
+    
+    expect(mockBacklog.getIssues).toHaveBeenCalledWith({
+      customField_11111: ["option1", "option2"]
+    });
+  });
+
+  it("calls backlog.getIssues with empty custom fields", async () => {
+    await tool.handler({
+      projectId: [100],
+      customFields: []
+    });
+    
+    expect(mockBacklog.getIssues).toHaveBeenCalledWith({
+      projectId: [100]
+    });
+  });
+
+  it("calls backlog.getIssues without custom fields", async () => {
+    await tool.handler({
+      projectId: [100],
+      statusId: [1]
+    });
+    
+    expect(mockBacklog.getIssues).toHaveBeenCalledWith({
+      projectId: [100],
+      statusId: [1]
+    });
+  });
 });

--- a/src/tools/getIssues.ts
+++ b/src/tools/getIssues.ts
@@ -37,7 +37,7 @@ const getIssuesSchema = buildToolSchema(t => ({
       z.number(),
       z.array(z.string())
     ]).describe(t("TOOL_GET_ISSUES_CUSTOM_FIELD_VALUE", "Custom field value"))
-  })).optional().describe(t("TOOL_GET_ISSUES_CUSTOM_FIELDS", "Custom field filters")),
+  })).optional().describe(t("TOOL_GET_ISSUES_CUSTOM_FIELDS", "Custom fields")),
 }));
 
 export const getIssuesTool = (backlog: Backlog, { t }: TranslationHelper): ToolDefinition<ReturnType<typeof getIssuesSchema>, typeof IssueSchema["shape"]> => {
@@ -47,8 +47,7 @@ export const getIssuesTool = (backlog: Backlog, { t }: TranslationHelper): ToolD
     schema: z.object(getIssuesSchema(t)),
     importantFields: ["projectId", "issueKey", "keyId", "summary", "description", "issueType"],
     outputSchema: IssueSchema,
-    handler: async (params) => {
-      const { customFields, ...rest } = params;
+    handler: async ({ customFields, ...rest }) => {
       return backlog.getIssues({
         ...rest,
         ...customFieldsToPayload(customFields)


### PR DESCRIPTION
## Description

This PR adds custom field filtering capability to the `getIssues` and `countIssues` tools.

## Changes

- Added `customFields` parameter to both tools' schemas
- Implemented custom field transformation using the existing `customFieldsToPayload` helper
- Added comprehensive test coverage for the new functionality

## Features

- Support for string, number, and array values in custom fields
- Maintains backward compatibility
- Follows Backlog API v2 specifications

## Testing

- Added 8 new test cases (4 for each tool)
- All existing tests continue to pass
- No linting errors

## Example Usage

```typescript
// Search for issues with specific custom field values
await mcp.getIssues({
  projectId: [100],
  customFields: [
    { id: 12345, value: "PROJECT-001" },
    { id: 67890, value: ["option1", "option2"] }
  ]
});
```

## Note

Due to Backlog API limitations, filtering by null custom field values is not supported directly. Users need to retrieve results and filter client-side for null values.