### PR TITLE
feat(dxt): Add DXT support for one-click installation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -22,13 +22,34 @@ Backlog API とやり取りするための Model Context Protocol（MCP）サー
 
 ### 必要条件
 
-- Docker
+- Docker または Node.js 18+
 - APIアクセスが可能なBacklogアカウント
 - BacklogアカウントのAPIキー
 
-### オプション1: Docker経由でのインストール
+### オプション1: DXTファイルでワンクリックインストール（推奨）
 
-このMCPサーバーを使用する最も簡単な方法は、MCP設定を利用することです：
+Claude Desktopユーザーの方は、DXTファイルを使用することで最も簡単にインストールできます：
+
+1. **DXTファイルをダウンロード**
+   - [Releases](https://github.com/nulab/backlog-mcp-server/releases)ページから最新の`backlog-mcp-server.dxt`をダウンロードします
+
+2. **Claude Desktopにインストール**
+   - ダウンロードした`.dxt`ファイルをダブルクリック、またはClaude Desktopにドラッグ＆ドロップします
+   - インストール確認ダイアログが表示されるので、内容を確認して「インストール」をクリックします
+
+3. **設定を入力**
+   - インストール時に以下の設定項目が表示されます：
+     - **Backlog Domain**: あなたのBacklogドメイン（例：`your-domain.backlog.com`）
+     - **Backlog API Key**: あなたのBacklog APIキー（[設定画面](https://your-domain.backlog.com/EditApiSettings.action)から取得）
+   - 必要な情報を入力して「保存」をクリックします
+
+4. **完了！**
+   - Claude Desktopが再起動され、Backlog MCPサーバーが利用可能になります
+   - 「Backlogで課題を検索して」などの指示をClaudeに送信できるようになります
+
+### オプション2: Docker経由でのインストール
+
+DXTファイルを使用しない場合は、Docker経由で手動設定することも可能です：
 
 1. MCP設定を開きます
 2. MCP設定セクションに移動します
@@ -65,7 +86,7 @@ Backlog API とやり取りするための Model Context Protocol（MCP）サー
 docker pull ghcr.io/nulab/backlog-mcp-server:latest
 ```
 
-### オプション2: 手動セットアップ (Node.js)
+### オプション3: 手動セットアップ (Node.js)
 
 1. クローンしてインストール：
    ```bash

--- a/README.md
+++ b/README.md
@@ -22,13 +22,34 @@ A Model Context Protocol (MCP) server for interacting with the Backlog API. This
 
 ### Requirements
 
-- Docker
+- Docker or Node.js 18+
 - A Backlog account with API access
 - API key from your Backlog account
 
-### Option 1: Install via Docker
+### Option 1: One-Click Install with DXT File (Recommended)
 
-The easiest way to use this MCP server is through MCP configurations:
+For Claude Desktop users, the easiest way to install is using a DXT file:
+
+1. **Download the DXT file**
+   - Download the latest `backlog-mcp-server.dxt` from the [Releases](https://github.com/nulab/backlog-mcp-server/releases) page
+
+2. **Install in Claude Desktop**
+   - Double-click the downloaded `.dxt` file or drag and drop it into Claude Desktop
+   - An installation confirmation dialog will appear - review and click "Install"
+
+3. **Configure settings**
+   - During installation, you'll be prompted to enter:
+     - **Backlog Domain**: Your Backlog domain (e.g., `your-domain.backlog.com`)
+     - **Backlog API Key**: Your Backlog API key (get it from [API Settings](https://your-domain.backlog.com/EditApiSettings.action))
+   - Enter the required information and click "Save"
+
+4. **Done!**
+   - Claude Desktop will restart and the Backlog MCP Server will be available
+   - You can now ask Claude to "Search for issues in Backlog" and more
+
+### Option 2: Install via Docker
+
+If you prefer not to use DXT files, you can manually configure via Docker:
 
 1. Open MCP settings
 2. Navigate to the MCP configuration section
@@ -65,7 +86,7 @@ Replace `your-domain.backlog.com` with your Backlog domain and `your-api-key` wi
 docker pull ghcr.io/nulab/backlog-mcp-server:latest
 ```
 
-### Option 2: Manual Setup (Node.js)
+### Option 3: Manual Setup (Node.js)
 
 1. Clone and install:
    ```bash

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,74 @@
+{
+  "dxt_version": "0.1",
+  "name": "backlog-mcp-server",
+  "version": "0.1.1",
+  "description": "A Model Context Protocol (MCP) server for interacting with the Backlog API. This server provides tools for managing projects, issues, wiki pages, and more in Backlog through AI agents.",
+  "display_name": "Backlog MCP Server",
+  "author": {
+    "name": "nulab",
+    "url": "https://github.com/nulab"
+  },
+  "homepage": "https://github.com/nulab/backlog-mcp-server",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nulab/backlog-mcp-server.git"
+  },
+  "keywords": ["mcp", "backlog", "api", "project-management", "issue-tracking"],
+  "server": {
+    "type": "node",
+    "entry_point": "build/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/build/index.js",
+        "--stdio"
+      ],
+      "env": {
+        "BACKLOG_DOMAIN": "${user_config.BACKLOG_DOMAIN}",
+        "BACKLOG_API_KEY": "${user_config.BACKLOG_API_KEY}"
+      }
+    }
+  },
+  "user_config": {
+    "BACKLOG_DOMAIN": {
+      "title": "Backlog Domain",
+      "description": "Your Backlog domain (e.g., your-domain.backlog.com)",
+      "type": "string",
+      "required": true,
+      "secret": false
+    },
+    "BACKLOG_API_KEY": {
+      "title": "Backlog API Key",
+      "description": "Your Backlog API key. Generate one from https://your-domain.backlog.com/EditApiSettings.action",
+      "type": "string",
+      "required": true,
+      "secret": true
+    }
+  },
+  "tools": [
+    {
+      "name": "project_management",
+      "description": "Create, read, update, and delete Backlog projects"
+    },
+    {
+      "name": "issue_tracking",
+      "description": "Manage issues and comments in Backlog"
+    },
+    {
+      "name": "wiki_pages",
+      "description": "Create and manage wiki pages"
+    },
+    {
+      "name": "git_repositories",
+      "description": "Access git repositories and pull requests"
+    },
+    {
+      "name": "notifications",
+      "description": "Manage Backlog notifications"
+    }
+  ],
+  "compatibility": {
+    "node": ">=18.0.0"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- Add DXT (Desktop Extension) support for easy one-click installation in Claude Desktop
- Create manifest.json with proper environment variable mappings
- Generate backlog-mcp-server.dxt package file

## Changes
- 📦 Add `manifest.json` configuration for DXT packaging
- 🚀 Generate `backlog-mcp-server.dxt` file for distribution
- 📝 Update READMEs with DXT installation instructions as the recommended method
- 🔧 Configure environment variable mapping for `BACKLOG_DOMAIN` and `BACKLOG_API_KEY`

## Test Plan
- [x] Successfully generated DXT file using `dxt pack`
- [x] Tested installation in Claude Desktop
- [x] Verified environment variables are properly passed to the server
- [x] Confirmed server starts without errors after installation

## Benefits
- Users can install the Backlog MCP Server with just one click
- No need for manual Docker or Node.js configuration
- Simplified setup process for non-technical users

🤖 Generated with [Claude Code](https://claude.ai/code)