### PR TITLE
chore: remove @jest/globals from tsconfig types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
       "esModuleInterop": true,
       "skipLibCheck": true,
       "forceConsistentCasingInFileNames": true,
-      "types": ["@jest/globals"],
       "isolatedModules": true
     },
     "include": ["src/**/*"],


### PR DESCRIPTION
## Summary
This PR removes `@jest/globals` from `compilerOptions.types` in `tsconfig.json` to resolve TypeScript compilation errors during the build process.

## Problem
When running `npm run build`, the TypeScript compiler fails with the following error:

```
error TS2688: Cannot find type definition file for '@jest/globals'.
  The file is in the program because:
    Entry point of type library '@jest/globals' specified in compilerOptions
```

This occurs because `tsconfig.json` specifies `"types": ["@jest/globals"]` in `compilerOptions`, but the package is not included in `devDependencies`.

## Solution
As suggested in the review, instead of adding `@jest/globals` as a devDependency, this PR removes the `@jest/globals` entry from `compilerOptions.types` in `tsconfig.json`.

Since the build configuration excludes `src/**/*.test.ts`, the `@jest/globals` type definition is not needed for the build process. Test files can still use Jest globals through the jest environment configuration.

## Changes
- Removed `"types": ["@jest/globals"]` from `tsconfig.json`

## Verification
- ✅ `npm run build` completes successfully
- ✅ All tests pass with `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)