### PR TITLE
fix: move env variable initialization after yargs parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,12 +20,6 @@ import { VERSION } from './version.js';
 
 dotenv.config();
 
-const domain = env.get('BACKLOG_DOMAIN').required().asString();
-
-const apiKey = env.get('BACKLOG_API_KEY').required().asString();
-
-const backlog = new backlogjs.Backlog({ host: domain, apiKey: apiKey });
-
 const argv = yargs(hideBin(process.argv))
   .option('max-tokens', {
     type: 'number',
@@ -67,6 +61,12 @@ Available toolsets:
     default: env.get('ENABLE_DYNAMIC_TOOLSETS').default('false').asBool(),
   })
   .parseSync();
+
+const domain = env.get('BACKLOG_DOMAIN').required().asString();
+
+const apiKey = env.get('BACKLOG_API_KEY').required().asString();
+
+const backlog = new backlogjs.Backlog({ host: domain, apiKey: apiKey });
 
 const useFields = argv.optimizeResponse;
 


### PR DESCRIPTION
## Summary
This PR moves the initialization of environment variables (`BACKLOG_DOMAIN` and `BACKLOG_API_KEY`) to after yargs argument parsing, allowing `--help` and `--version` commands to work without requiring environment variables.

## Problem
Currently, when users try to run `--help` or `--version`, they encounter an error:

```
EnvVarError: env-var: "BACKLOG_DOMAIN" is a required variable, but it was not set
```

This happens because environment variable validation occurs before yargs parses the command-line arguments. Help and version commands should not require environment variables to be set.

## Changes
- Moved `BACKLOG_DOMAIN` and `BACKLOG_API_KEY` initialization from before yargs parsing to after `parseSync()`
- This allows help and version commands to execute before environment validation

## Verification
- ✅ `node build/index.js --help` works without environment variables
- ✅ `node build/index.js --version` works without environment variables
- ✅ Server still requires environment variables when actually starting

## Notes
This is a minimal change that improves the user experience by allowing users to view help and version information without setting up environment variables first.