### PR TITLE
feat: add delete_document tool

### DIFF
--- a/src/tools/deleteDocument.test.ts
+++ b/src/tools/deleteDocument.test.ts
@@ -1,0 +1,72 @@
+import { deleteDocumentTool } from './deleteDocument.js';
+import { vi, describe, it, expect } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+
+describe('deleteDocumentTool', () => {
+  const mockBacklog: Partial<Backlog> = {
+    deleteDocument: vi.fn<() => Promise<any>>().mockResolvedValue({
+      id: '019347fc760c7b0abff04b44628c94d7',
+      projectId: 1,
+      title: 'Test Document',
+      plain: 'This is a test document.',
+      json: '{}',
+      statusId: 1,
+      emoji: null,
+      attachments: [],
+      tags: [],
+      createdUser: {
+        id: 2,
+        userId: 'woody',
+        name: 'woody',
+        roleType: 1,
+        lang: 'en',
+        mailAddress: 'woody@nulab.com',
+        nulabAccount: null,
+        keyword: 'Woody',
+        lastLoginTime: '2025-05-28T22:24:36Z',
+      },
+      created: '2024-12-06T01:08:56Z',
+      updatedUser: {
+        id: 2,
+        userId: 'woody',
+        name: 'woody',
+        roleType: 1,
+        lang: 'en',
+        mailAddress: 'woody@nulab.com',
+        nulabAccount: null,
+        keyword: 'Woody',
+        lastLoginTime: '2025-05-28T22:24:36Z',
+      },
+      updated: '2025-04-28T01:47:02Z',
+    }),
+  };
+
+  const mockTranslationHelper = createTranslationHelper();
+  const tool = deleteDocumentTool(
+    mockBacklog as Backlog,
+    mockTranslationHelper
+  );
+
+  it('returns deleted document as formatted JSON text', async () => {
+    const result = await tool.handler({
+      documentId: '019347fc760c7b0abff04b44628c94d7',
+    });
+    if (Array.isArray(result)) {
+      throw new Error('Unexpected array result');
+    }
+
+    expect(result.title).toContain('Test Document');
+    expect(result.id).toBe('019347fc760c7b0abff04b44628c94d7');
+  });
+
+  it('calls backlog.deleteDocument with correct params', async () => {
+    await tool.handler({
+      documentId: '019347fc760c7b0abff04b44628c94d7',
+    });
+
+    expect(mockBacklog.deleteDocument).toHaveBeenCalledWith(
+      '019347fc760c7b0abff04b44628c94d7'
+    );
+  });
+});

--- a/src/tools/deleteDocument.ts
+++ b/src/tools/deleteDocument.ts
@@ -1,0 +1,32 @@
+import { Backlog } from 'backlog-js';
+import { z } from 'zod';
+import { TranslationHelper } from '../createTranslationHelper.js';
+import { DocumentItemSchema } from '../types/zod/backlogOutputDefinition.js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+
+const deleteDocumentSchema = buildToolSchema((t) => ({
+  documentId: z
+    .string()
+    .describe(t('TOOL_DELETE_DOCUMENT_DOCUMENT_ID', 'Document ID')),
+}));
+
+export const deleteDocumentTool = (
+  backlog: Backlog,
+  { t }: TranslationHelper
+): ToolDefinition<
+  ReturnType<typeof deleteDocumentSchema>,
+  (typeof DocumentItemSchema)['shape']
+> => {
+  return {
+    name: 'delete_document',
+    description: t(
+      'TOOL_DELETE_DOCUMENT_DESCRIPTION',
+      'Permanently deletes a document. This is irreversible (hard delete) and the document cannot be recovered. Unlike the Backlog UI trash feature, this operation does not move the document to trash.'
+    ),
+    schema: z.object(deleteDocumentSchema(t)),
+    outputSchema: DocumentItemSchema,
+    handler: async ({ documentId }) => {
+      return backlog.deleteDocument(documentId);
+    },
+  };
+};

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -56,6 +56,7 @@ import { addVersionMilestoneTool } from './addVersionMilestone.js';
 import { updateVersionMilestoneTool } from './updateVersionMilestone.js';
 import { deleteVersionTool } from './deleteVersion.js';
 import { addDocumentTool } from './addDocument.js';
+import { deleteDocumentTool } from './deleteDocument.js';
 
 export const allTools = (
   backlog: Backlog,
@@ -156,6 +157,7 @@ export const allTools = (
           getDocumentTreeTool(backlog, helper),
           getDocumentTool(backlog, helper),
           addDocumentTool(backlog, helper),
+          deleteDocumentTool(backlog, helper),
         ],
       },
       {


### PR DESCRIPTION
## Summary

- Add `delete_document` tool to permanently delete a document via Backlog API (`DELETE /api/v2/documents/:documentId`)
- Tool description explicitly warns that this is an **irreversible hard delete**, unlike the Backlog UI "move to trash" feature
- Includes unit tests (2 test cases)

## Related Issue

Closes #64

## Notes

- `backlog-js` already provides `deleteDocument()` method ([backlog-js PR #128](https://github.com/nulab/backlog-js/pull/128))
- The DELETE API performs a **permanent deletion** (confirmed by testing) — the document cannot be recovered and does not appear in the Document Tree `trashTree`
- Implementation follows existing patterns (`deleteIssue`, `addDocument`)