### PR TITLE
feat: enable npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -28,7 +29,11 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci

--- a/.release-it.json
+++ b/.release-it.json
@@ -16,7 +16,10 @@
     "releaseName": "v${version}",
     "tokenRef": "GITHUB_TOKEN"
   },
-  "npm": false,
+  "npm": {
+    "publish": true,
+    "skipChecks": true
+  },
   "hooks": {
     "after:bump": "docker buildx build --platform linux/amd64,linux/arm64 --provenance=false --sbom=false --build-arg VERSION=${version} -t ghcr.io/nulab/backlog-mcp-server:v${version} -t ghcr.io/nulab/backlog-mcp-server:latest --push ."
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "backlog-mcp-server": "./build/index.js"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nulab/backlog-mcp-server.git"
+  },
   "scripts": {
     "dev": "tsx src/index.ts",
     "build": "tsc && chmod 755 build/index.js",


### PR DESCRIPTION
## Summary
- Switch npm publish to tokenless Trusted Publishing (OIDC)
- Add `id-token: write`, `registry-url`, and npm upgrade step to `release.yml`
- Enable `npm.publish: true` + `skipChecks: true` in `.release-it.json`
- Add `repository` field to `package.json` for provenance linking

## Remaining steps
- [x] Register GitHub Actions as a Trusted Publisher on npmjs.com: backlog-mcp-server **Settings → Trusted publishing** (`nulab` / `backlog-mcp-server` / `release.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)