### PR TITLE
fix: add build step before npm publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build
+        run: npm run build
+
       - name: Set up QEMU for cross-platform builds
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## Summary
- Add `npm run build` step in release workflow before `release-it` runs
- Without this, npm publish fails because `build/index.js` doesn't exist

Cherry-picked from 9f02f22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)