### PR TITLE
feat: add multi-organization support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 BACKLOG_API_KEY=your-api-key
 BACKLOG_DOMAIN=your-domain.backlog.com
+# Optional: point to a YAML file with multiple organizations.
+# BACKLOG_ORGANIZATIONS_CONFIG=./backlog-organizations.yml

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
 BACKLOG_API_KEY=your-api-key
 BACKLOG_DOMAIN=your-domain.backlog.com
-# Optional: point to a YAML file with multiple organizations.
-# BACKLOG_ORGANIZATIONS_CONFIG=./backlog-organizations.yml
+# Optional multi-organization configuration.
+# BACKLOG_DEFAULT_ORG=COMPANY_A
+# BACKLOG_ORG_COMPANY_A_DOMAIN=company-a.backlog.com
+# BACKLOG_ORG_COMPANY_A_API_KEY=your-company-a-api-key
+# BACKLOG_ORG_COMPANY_B_DOMAIN=company-b.backlog.com
+# BACKLOG_ORG_COMPANY_B_API_KEY=your-company-b-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ dist/
 .env.development.local
 .env.test.local
 .env.production.local
+backlog-organizations.yml
+.codex/
 
 # Editor directories and files
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ dist/
 .env.development.local
 .env.test.local
 .env.production.local
-backlog-organizations.yml
 .codex/
 
 # Editor directories and files

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ dist/
 .env.development.local
 .env.test.local
 .env.production.local
-.codex/
 
 # Editor directories and files
 .idea/

--- a/README.ja.md
+++ b/README.ja.md
@@ -507,6 +507,93 @@ npm test
 node build/index.js --optimize-response --max-tokens=100000 --prefix="backlog_" --enable-toolsets space,issue
 ```
 
+## 複数組織対応
+
+このサーバーは、1つのMCPサーバーインスタンスから複数のBacklog組織にアクセスできるよう設定できます。
+
+### 設定
+
+組織ごとに環境変数のペアを定義し、デフォルト組織を設定します。
+
+```bash
+BACKLOG_DEFAULT_ORG=COMPANY_A
+BACKLOG_ORG_COMPANY_A_DOMAIN=company-a.backlog.com
+BACKLOG_ORG_COMPANY_A_API_KEY=your-company-a-api-key
+BACKLOG_ORG_COMPANY_B_DOMAIN=company-b.backlog.com
+BACKLOG_ORG_COMPANY_B_API_KEY=your-company-b-api-key
+```
+
+これらの変数は、ローカルの`.env`、シェル環境変数、またはMCPクライアント設定の`env`ブロックのいずれからでも利用できます。
+
+MCP設定例：
+
+```json
+{
+  "mcpServers": {
+    "backlog": {
+      "env": {
+        "BACKLOG_DEFAULT_ORG": "COMPANY_A",
+        "BACKLOG_ORG_COMPANY_A_DOMAIN": "company-a.backlog.com",
+        "BACKLOG_ORG_COMPANY_A_API_KEY": "your-company-a-api-key",
+        "BACKLOG_ORG_COMPANY_B_DOMAIN": "company-b.backlog.com",
+        "BACKLOG_ORG_COMPANY_B_API_KEY": "your-company-b-api-key"
+      }
+    }
+  }
+}
+```
+
+複数組織用の環境変数が設定されていない場合、サーバーは従来どおり単一組織用の設定にフォールバックします。
+
+```bash
+BACKLOG_DOMAIN=your-domain.backlog.com
+BACKLOG_API_KEY=your-api-key
+```
+
+### ツールの使い方
+
+通常のツールはすべて、任意の`organization`入力フィールドを受け付けます。指定した場合、そのBacklog組織に対してツールが実行されます。
+
+例：
+
+```json
+{
+  "organization": "COMPANY_B",
+  "projectKey": "PROJECT"
+}
+```
+
+`organization`を省略した場合：
+
+- `BACKLOG_DEFAULT_ORG`で指定した組織が使われます
+- 複数組織用の環境変数が存在するのに`BACKLOG_DEFAULT_ORG`が未設定の場合、サーバーは起動時に失敗します
+
+### 組織一覧の確認
+
+サーバーは `list_organizations` ツールを提供しており、設定済みの組織名、ドメイン、デフォルト組織かどうかを返します。
+
+レスポンス例：
+
+```json
+[
+  {
+    "name": "COMPANY_A",
+    "domain": "company-a.backlog.com",
+    "isDefault": true
+  },
+  {
+    "name": "COMPANY_B",
+    "domain": "company-b.backlog.com",
+    "isDefault": false
+  }
+]
+```
+
+### 注意
+
+- 複数組織モードでは、各組織に対して `BACKLOG_ORG_<NAME>_DOMAIN` と `BACKLOG_ORG_<NAME>_API_KEY` の両方を定義する必要があります
+- `<NAME>` の部分が、`organization`入力や `list_organizations` に表示される組織名になります
+
 ## ライセンス
 
 このプロジェクトは [MITライセンス](./LICENSE) のもとでライセンスされています。

--- a/README.md
+++ b/README.md
@@ -594,3 +594,79 @@ This project is licensed under the [MIT License](./LICENSE).
 Please note: This tool is provided under the MIT License **without any warranty or official support**.  
 Use it at your own risk after reviewing the contents and determining its suitability for your needs.  
 If you encounter any issues, please report them via [GitHub Issues](../../issues).
+
+## Multi-Organization Support
+
+This server can be configured to access multiple Backlog organizations from a single MCP server instance.
+
+### Configuration
+
+Set `BACKLOG_ORGANIZATIONS_CONFIG` to the path of a YAML file:
+
+```yaml
+defaultOrg: org1
+organizations:
+  org1:
+    domain: org1.backlog.com
+    apiKey: your-org1-api-key
+  org2:
+    domain: org2.backlog.com
+    apiKey: your-org2-api-key
+```
+
+Example `.env`:
+
+```bash
+BACKLOG_ORGANIZATIONS_CONFIG=./backlog-organizations.yml
+```
+
+If `BACKLOG_ORGANIZATIONS_CONFIG` is not set, the server falls back to the existing single-organization configuration:
+
+```bash
+BACKLOG_DOMAIN=your-domain.backlog.com
+BACKLOG_API_KEY=your-api-key
+```
+
+### Tool Usage
+
+All normal tools accept an optional `organization` input field. When provided, the tool call is routed to that Backlog organization.
+
+Examples:
+
+```json
+{
+  "organization": "org2",
+  "projectKey": "PROJECT"
+}
+```
+
+If `organization` is omitted:
+
+- the `defaultOrg` from the YAML file is used
+- if multiple organizations are configured and no `defaultOrg` is set, the tool returns an error asking for `organization`
+
+### Organization Discovery
+
+The server provides a `list_organizations` tool that returns the configured organization names, their domains, and which one is the default.
+
+Example response:
+
+```json
+[
+  {
+    "name": "org1",
+    "domain": "org1.backlog.com",
+    "isDefault": true
+  },
+  {
+    "name": "org2",
+    "domain": "org2.backlog.com",
+    "isDefault": false
+  }
+]
+```
+
+### Notes
+
+- YAML config files should not be committed if they contain real API keys.
+- A sample file is available at `backlog-organizations.yml.example`.

--- a/README.md
+++ b/README.md
@@ -587,40 +587,39 @@ Example:
 node build/index.js --optimize-response --max-tokens=100000 --prefix="backlog_" --enable-toolsets space,issue
 ```
 
-## License
-
-This project is licensed under the [MIT License](./LICENSE).
-
-Please note: This tool is provided under the MIT License **without any warranty or official support**.  
-Use it at your own risk after reviewing the contents and determining its suitability for your needs.  
-If you encounter any issues, please report them via [GitHub Issues](../../issues).
-
 ## Multi-Organization Support
 
 This server can be configured to access multiple Backlog organizations from a single MCP server instance.
 
 ### Configuration
 
-Set `BACKLOG_ORGANIZATIONS_CONFIG` to the path of a YAML file:
-
-```yaml
-defaultOrg: org1
-organizations:
-  org1:
-    domain: org1.backlog.com
-    apiKey: your-org1-api-key
-  org2:
-    domain: org2.backlog.com
-    apiKey: your-org2-api-key
-```
-
-Example `.env`:
+Configure one env pair per organization and set a default organization:
 
 ```bash
-BACKLOG_ORGANIZATIONS_CONFIG=./backlog-organizations.yml
+BACKLOG_DEFAULT_ORG=COMPANY_A
+BACKLOG_ORG_COMPANY_A_DOMAIN=company-a.backlog.com
+BACKLOG_ORG_COMPANY_A_API_KEY=your-company-a-api-key
+BACKLOG_ORG_COMPANY_B_DOMAIN=company-b.backlog.com
+BACKLOG_ORG_COMPANY_B_API_KEY=your-company-b-api-key
 ```
 
-If `BACKLOG_ORGANIZATIONS_CONFIG` is not set, the server falls back to the existing single-organization configuration:
+This works whether the variables come from a local `.env`, your shell environment, or an MCP client config `env` block.
+
+Example MCP config:
+
+```json
+{
+  "env": {
+    "BACKLOG_DEFAULT_ORG": "COMPANY_A",
+    "BACKLOG_ORG_COMPANY_A_DOMAIN": "company-a.backlog.com",
+    "BACKLOG_ORG_COMPANY_A_API_KEY": "your-company-a-api-key",
+    "BACKLOG_ORG_COMPANY_B_DOMAIN": "company-b.backlog.com",
+    "BACKLOG_ORG_COMPANY_B_API_KEY": "your-company-b-api-key"
+  }
+}
+```
+
+If no multi-organization env vars are set, the server falls back to the existing single-organization configuration:
 
 ```bash
 BACKLOG_DOMAIN=your-domain.backlog.com
@@ -635,15 +634,15 @@ Examples:
 
 ```json
 {
-  "organization": "org2",
+  "organization": "COMPANY_B",
   "projectKey": "PROJECT"
 }
 ```
 
 If `organization` is omitted:
 
-- the `defaultOrg` from the YAML file is used
-- if multiple organizations are configured and no `defaultOrg` is set, the tool returns an error asking for `organization`
+- the organization named by `BACKLOG_DEFAULT_ORG` is used
+- if multi-organization env vars are present and `BACKLOG_DEFAULT_ORG` is missing, the server fails at startup
 
 ### Organization Discovery
 
@@ -654,13 +653,13 @@ Example response:
 ```json
 [
   {
-    "name": "org1",
-    "domain": "org1.backlog.com",
+    "name": "COMPANY_A",
+    "domain": "company-a.backlog.com",
     "isDefault": true
   },
   {
-    "name": "org2",
-    "domain": "org2.backlog.com",
+    "name": "COMPANY_B",
+    "domain": "company-b.backlog.com",
     "isDefault": false
   }
 ]
@@ -668,5 +667,13 @@ Example response:
 
 ### Notes
 
-- YAML config files should not be committed if they contain real API keys.
-- A sample file is available at `backlog-organizations.yml.example`.
+- For multi-org mode, every organization must define both `BACKLOG_ORG_<NAME>_DOMAIN` and `BACKLOG_ORG_<NAME>_API_KEY`.
+- The `<NAME>` part is the organization name exposed through the `organization` tool input and `list_organizations`.
+
+## License
+
+This project is licensed under the [MIT License](./LICENSE).
+
+Please note: This tool is provided under the MIT License **without any warranty or official support**.  
+Use it at your own risk after reviewing the contents and determining its suitability for your needs.  
+If you encounter any issues, please report them via [GitHub Issues](../../issues).

--- a/backlog-organizations.yml.example
+++ b/backlog-organizations.yml.example
@@ -1,0 +1,8 @@
+defaultOrg: org1
+organizations:
+  org1:
+    domain: org1.backlog.com
+    apiKey: your-org1-api-key
+  org2:
+    domain: org2.backlog.com
+    apiKey: your-org2-api-key

--- a/backlog-organizations.yml.example
+++ b/backlog-organizations.yml.example
@@ -1,8 +1,0 @@
-defaultOrg: org1
-organizations:
-  org1:
-    domain: org1.backlog.com
-    apiKey: your-org1-api-key
-  org2:
-    domain: org2.backlog.com
-    apiKey: your-org2-api-key

--- a/src/handlers/builders/composeToolHandler.test.ts
+++ b/src/handlers/builders/composeToolHandler.test.ts
@@ -45,7 +45,7 @@ describe('composeToolHandler', () => {
     expect(tool.schema.shape).toHaveProperty('fields');
 
     const result = await composed(
-      { id: 123, fields: '{ id }' } as any,
+      { id: 123, fields: '{ id }' },
       dummyExtra
     );
     const content = (result as CallToolResult).content[0];
@@ -74,7 +74,7 @@ describe('composeToolHandler', () => {
     expect(toolWithoutFields.schema.shape).not.toHaveProperty('fields');
     expect(toolWithoutFields.schema.shape).toHaveProperty('organization');
 
-    const result = await composed({ id: 456 } as any, dummyExtra);
+    const result = await composed({ id: 456 }, dummyExtra);
     const content = (result as CallToolResult).content[0];
     expect(content.type).toBe('text');
     if (content.type === 'text') {
@@ -91,7 +91,7 @@ describe('composeToolHandler', () => {
     });
 
     const input = { name: 'test', fields: '{ id name }' };
-    const result = await composed(input as any, {} as any);
+    const result = await composed(input, {} as any);
     expect(result).toHaveProperty('content');
     const content = result.content[0];
     expect(content.type).toBe('text');
@@ -132,7 +132,7 @@ describe('composeToolHandler', () => {
     });
 
     const input = { name: 'test', fields: '{ id name }' };
-    const result = await composed(input as any, {} as any);
+    const result = await composed(input, {} as any);
     expect(result).toHaveProperty('isError', true);
     const content = result.content[0];
     if (content.type === 'text') {

--- a/src/handlers/builders/composeToolHandler.test.ts
+++ b/src/handlers/builders/composeToolHandler.test.ts
@@ -44,10 +44,7 @@ describe('composeToolHandler', () => {
 
     expect(tool.schema.shape).toHaveProperty('fields');
 
-    const result = await composed(
-      { id: 123, fields: '{ id }' },
-      dummyExtra
-    );
+    const result = await composed({ id: 123, fields: '{ id }' }, dummyExtra);
     const content = (result as CallToolResult).content[0];
     expect(content.type).toBe('text');
     if (content.type === 'text') {

--- a/src/handlers/builders/composeToolHandler.test.ts
+++ b/src/handlers/builders/composeToolHandler.test.ts
@@ -44,7 +44,10 @@ describe('composeToolHandler', () => {
 
     expect(tool.schema.shape).toHaveProperty('fields');
 
-    const result = await composed({ id: 123, fields: '{ id }' }, dummyExtra);
+    const result = await composed(
+      { id: 123, fields: '{ id }' } as any,
+      dummyExtra
+    );
     const content = (result as CallToolResult).content[0];
     expect(content.type).toBe('text');
     if (content.type === 'text') {
@@ -69,8 +72,9 @@ describe('composeToolHandler', () => {
     });
 
     expect(toolWithoutFields.schema.shape).not.toHaveProperty('fields');
+    expect(toolWithoutFields.schema.shape).toHaveProperty('organization');
 
-    const result = await composed({ id: 456 }, dummyExtra);
+    const result = await composed({ id: 456 } as any, dummyExtra);
     const content = (result as CallToolResult).content[0];
     expect(content.type).toBe('text');
     if (content.type === 'text') {
@@ -87,7 +91,7 @@ describe('composeToolHandler', () => {
     });
 
     const input = { name: 'test', fields: '{ id name }' };
-    const result = await composed(input, {} as any);
+    const result = await composed(input as any, {} as any);
     expect(result).toHaveProperty('content');
     const content = result.content[0];
     expect(content.type).toBe('text');
@@ -95,6 +99,22 @@ describe('composeToolHandler', () => {
       expect(content.text).toContain('"id": 1');
       expect(content.text).toContain('"name": "Sample"');
     }
+  });
+
+  it("adds 'organization' to the schema when composing handlers", async () => {
+    const orgTool: ToolDefinition<any, any> = {
+      ...tool,
+      schema: z.object({
+        name: z.string(),
+      }),
+    };
+
+    composeToolHandler(orgTool, {
+      useFields: true,
+      maxTokens: 100,
+    });
+
+    expect(orgTool.schema.shape).toHaveProperty('organization');
   });
 
   it('handles error with provided errorHandler', async () => {
@@ -112,7 +132,7 @@ describe('composeToolHandler', () => {
     });
 
     const input = { name: 'test', fields: '{ id name }' };
-    const result = await composed(input, {} as any);
+    const result = await composed(input as any, {} as any);
     expect(result).toHaveProperty('isError', true);
     const content = result.content[0];
     if (content.type === 'text') {

--- a/src/handlers/builders/composeToolHandler.ts
+++ b/src/handlers/builders/composeToolHandler.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { wrapWithErrorHandling } from '../transformers/wrapWithErrorHandling.js';
 import { wrapWithFieldPicking } from '../transformers/wrapWithFieldPicking.js';
+import { wrapWithOrganizationContext } from '../transformers/wrapWithOrganizationContext.js';
 import { wrapWithTokenLimit } from '../transformers/wrapWithTokenLimit.js';
 import { wrapWithToolResult } from '../transformers/wrapWithToolResult.js';
 import { z } from 'zod';
@@ -21,17 +22,20 @@ export function composeToolHandler(
   const { useFields, errorHandler, maxTokens } = options;
 
   // Step 1: Add `fields` to schema if needed
-  if (useFields) {
-    const fieldDesc = generateFieldsDescription(
-      tool.outputSchema,
-      (tool.importantFields as string[]) ?? [],
-      tool.name
-    );
-    tool.schema = extendSchema(tool.schema, fieldDesc);
-  }
+  const fieldDesc = useFields
+    ? generateFieldsDescription(
+        tool.outputSchema,
+        (tool.importantFields as string[]) ?? [],
+        tool.name
+      )
+    : undefined;
+  tool.schema = extendSchema(tool.schema, fieldDesc);
 
   // Step 2: Compose
-  let handler = wrapWithErrorHandling(tool.handler, errorHandler);
+  let handler: any = wrapWithErrorHandling(
+    wrapWithOrganizationContext(tool.handler as any),
+    errorHandler
+  );
 
   if (useFields) {
     handler = wrapWithFieldPicking(handler);
@@ -42,9 +46,30 @@ export function composeToolHandler(
 
 function extendSchema<I extends z.ZodRawShape>(
   schema: z.ZodObject<I>,
-  desc: string
-): z.ZodObject<I & { fields: z.ZodString }> {
-  return schema.extend({
-    fields: z.string().describe(desc),
-  }) as z.ZodObject<I & { fields: z.ZodString }>;
+  desc?: string
+): z.ZodObject<
+  I & {
+    organization: z.ZodOptional<z.ZodString>;
+    fields?: z.ZodString;
+  }
+> {
+  const extension: Record<string, z.ZodTypeAny> = {
+    organization: z
+      .string()
+      .optional()
+      .describe(
+        'Optional organization name. Use list_organizations to inspect available organizations.'
+      ),
+  };
+
+  if (desc) {
+    extension.fields = z.string().describe(desc);
+  }
+
+  return schema.extend(extension) as z.ZodObject<
+    I & {
+      organization: z.ZodOptional<z.ZodString>;
+      fields?: z.ZodString;
+    }
+  >;
 }

--- a/src/handlers/builders/composeToolHandler.ts
+++ b/src/handlers/builders/composeToolHandler.ts
@@ -6,7 +6,7 @@ import { wrapWithTokenLimit } from '../transformers/wrapWithTokenLimit.js';
 import { wrapWithToolResult } from '../transformers/wrapWithToolResult.js';
 import { z } from 'zod';
 import { generateFieldsDescription } from '../../utils/generateFieldsDescription.js';
-import { ErrorLike } from '../../types/result.js';
+import { ErrorLike, SafeResult } from '../../types/result.js';
 import { ToolDefinition } from '../../types/tool.js';
 
 interface ComposeOptions {
@@ -14,6 +14,13 @@ interface ComposeOptions {
   errorHandler?: (err: unknown) => ErrorLike;
   maxTokens: number;
 }
+
+type ComposedInput = {
+  fields?: string;
+  organization?: string;
+} & Record<string, unknown>;
+
+type ComposedHandler = (input: ComposedInput) => Promise<SafeResult<unknown>>;
 
 export function composeToolHandler(
   tool: ToolDefinition<any, any>,
@@ -32,8 +39,8 @@ export function composeToolHandler(
   tool.schema = extendSchema(tool.schema, fieldDesc);
 
   // Step 2: Compose
-  let handler: any = wrapWithErrorHandling(
-    wrapWithOrganizationContext(tool.handler as any),
+  let handler: ComposedHandler = wrapWithErrorHandling(
+    wrapWithOrganizationContext(tool.handler),
     errorHandler
   );
 

--- a/src/handlers/transformers/wrapWithOrganizationContext.ts
+++ b/src/handlers/transformers/wrapWithOrganizationContext.ts
@@ -1,0 +1,15 @@
+import { runWithOrganization } from '../../utils/backlogOrganizationContext.js';
+
+export function wrapWithOrganizationContext<
+  I extends { organization?: string },
+  O,
+>(
+  fn: (input: Omit<I, 'organization'>) => Promise<O>
+): (input: I) => Promise<O> {
+  return async (input: I) => {
+    const { organization, ...rest } = input;
+    return runWithOrganization(organization, () =>
+      fn(rest as Omit<I, 'organization'>)
+    );
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,15 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import * as backlogjs from 'backlog-js';
 import dotenv from 'dotenv';
 import { default as env } from 'env-var';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { createTranslationHelper } from './createTranslationHelper.js';
 import { registerDynamicTools, registerTools } from './registerTools.js';
+import { organizationTools } from './tools/dynamicTools/organizations.js';
 import { dynamicTools } from './tools/dynamicTools/toolsets.js';
+import { createBacklogClientRegistry } from './utils/backlogClientRegistry.js';
 import { logger } from './utils/logger.js';
 import { createToolRegistrar } from './utils/toolRegistrar.js';
 import { buildToolsetGroup } from './utils/toolsetUtils.js';
@@ -63,11 +64,8 @@ Available toolsets:
   })
   .parseSync();
 
-const domain = env.get('BACKLOG_DOMAIN').required().asString();
-
-const apiKey = env.get('BACKLOG_API_KEY').required().asString();
-
-const backlog = new backlogjs.Backlog({ host: domain, apiKey: apiKey });
+const clientRegistry = createBacklogClientRegistry();
+const backlog = clientRegistry.createScopedClient();
 
 const useFields = argv.optimizeResponse;
 
@@ -95,6 +93,11 @@ const toolsetGroup = buildToolsetGroup(backlog, transHelper, enabledToolsets);
 
 // Register all tools
 registerTools(server, toolsetGroup, mcpOption);
+registerDynamicTools(
+  server,
+  organizationTools(clientRegistry, transHelper),
+  prefix
+);
 
 // Register dynamic tool management tools if enabled
 if (argv.dynamicToolsets) {

--- a/src/tools/dynamicTools/organizations.test.ts
+++ b/src/tools/dynamicTools/organizations.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { createTranslationHelper } from '../../createTranslationHelper.js';
+import { organizationTools } from './organizations.js';
+import { BacklogClientRegistry } from '../../utils/backlogClientRegistry.js';
+
+describe('organizationTools', () => {
+  it('returns configured organizations and default status', async () => {
+    const registry: BacklogClientRegistry = {
+      resolveClient: () => {
+        throw new Error('unused');
+      },
+      createScopedClient: () => {
+        throw new Error('unused');
+      },
+      listOrganizations: () => [
+        { name: 'primary', domain: 'primary.backlog.com', isDefault: true },
+        {
+          name: 'secondary',
+          domain: 'secondary.backlog.com',
+          isDefault: false,
+        },
+      ],
+      getDefaultOrganization: () => 'primary',
+    };
+
+    const group = organizationTools(registry, createTranslationHelper());
+    const tool = group.toolsets[0].tools[0];
+    const result = await tool.handler({});
+    const content = result.content[0];
+
+    expect(content.type).toBe('text');
+    if (content.type === 'text') {
+      expect(JSON.parse(content.text)).toEqual([
+        {
+          name: 'primary',
+          domain: 'primary.backlog.com',
+          isDefault: true,
+        },
+        {
+          name: 'secondary',
+          domain: 'secondary.backlog.com',
+          isDefault: false,
+        },
+      ]);
+    }
+  });
+});

--- a/src/tools/dynamicTools/organizations.ts
+++ b/src/tools/dynamicTools/organizations.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { TranslationHelper } from '../../createTranslationHelper.js';
+import {
+  BacklogClientRegistry,
+  BacklogOrganizationInfo,
+} from '../../utils/backlogClientRegistry.js';
+import { DynamicToolDefinition } from '../../types/tool.js';
+import { DynamicToolsetGroup } from '../../types/toolsets.js';
+
+export function organizationTools(
+  registry: BacklogClientRegistry,
+  { t }: TranslationHelper
+): DynamicToolsetGroup {
+  return {
+    toolsets: [
+      {
+        name: 'organization_metadata',
+        description: 'Tools for inspecting configured Backlog organizations.',
+        enabled: true,
+        tools: [listOrganizationsTool(registry, t)],
+      },
+    ],
+  };
+}
+
+export function listOrganizationsTool(
+  registry: BacklogClientRegistry,
+  t: TranslationHelper['t']
+): DynamicToolDefinition<Record<string, never>> {
+  return {
+    name: 'list_organizations',
+    description: t(
+      'TOOL_LIST_ORGANIZATIONS_DESCRIPTION',
+      'List configured Backlog organizations and identify the default organization.'
+    ),
+    schema: z.object({}),
+    handler: async () => {
+      const organizations = registry.listOrganizations().map(toToolOutput);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(organizations, null, 2),
+          },
+        ],
+      };
+    },
+  };
+}
+
+function toToolOutput(organization: BacklogOrganizationInfo) {
+  return {
+    name: organization.name,
+    domain: organization.domain,
+    isDefault: organization.isDefault,
+  };
+}

--- a/src/tools/dynamicTools/toolsets.ts
+++ b/src/tools/dynamicTools/toolsets.ts
@@ -43,7 +43,7 @@ export const enableToolsetTool = (
     name: 'enable_toolset',
     description: t(
       'TOOL_ENABLE_TOOLSET_DESCRIPTION',
-      'Enable one of the sets of tools the GitHub MCP server provides, use get_toolset_tools and list_available_toolsets first to see what this will enable'
+      'Enable one of the Backlog MCP server toolsets. Use get_toolset_tools and list_available_toolsets first to inspect what this will enable.'
     ),
     schema: z.object(enableToolsetSchema(t)),
     handler: async ({ toolset }) => {

--- a/src/types/tool.ts
+++ b/src/types/tool.ts
@@ -11,7 +11,10 @@ export type ToolDefinition<
   schema: z.ZodObject<Shape>;
   outputSchema: z.ZodObject<OutputShape>;
   handler: (
-    input: z.infer<z.ZodObject<Shape>> & { fields?: string }
+    input: z.infer<z.ZodObject<Shape>> & {
+      fields?: string;
+      organization?: string;
+    }
   ) => Promise<
     z.infer<z.ZodObject<OutputShape>> | z.infer<z.ZodObject<OutputShape>>[]
   >;

--- a/src/utils/backlogClientRegistry.test.ts
+++ b/src/utils/backlogClientRegistry.test.ts
@@ -162,6 +162,31 @@ describe('createBacklogClientRegistry', () => {
     ).toThrow('Incomplete multi-organization configuration');
   });
 
+  it('rejects unknown organizations in single-org mode via scoped client', async () => {
+    const registry = createBacklogClientRegistry({
+      env: {
+        BACKLOG_DOMAIN: 'single.backlog.com',
+        BACKLOG_API_KEY: 'single-key',
+      },
+    });
+
+    const tool = getSpaceTool(
+      registry.createScopedClient(),
+      createTranslationHelper()
+    );
+    const handler = composeToolHandler(tool, {
+      useFields: false,
+      maxTokens: 5000,
+    });
+
+    const result = await handler({ organization: 'NONEXISTENT' }, {} as never);
+    expect(result.isError).toBe(true);
+    const content = result.content[0];
+    if (content.type === 'text') {
+      expect(content.text).toContain("Unknown organization 'NONEXISTENT'");
+    }
+  });
+
   it('prefers multi-org env config over single-org fallback env vars', async () => {
     const registry = createBacklogClientRegistry({
       env: {

--- a/src/utils/backlogClientRegistry.test.ts
+++ b/src/utils/backlogClientRegistry.test.ts
@@ -159,9 +159,7 @@ describe('createBacklogClientRegistry', () => {
           BACKLOG_ORG_SECONDARY_API_KEY: 'secondary-key',
         },
       })
-    ).toThrow(
-      'Each multi-organization config must define both BACKLOG_ORG_<NAME>_DOMAIN and BACKLOG_ORG_<NAME>_API_KEY. Incomplete organizations: PRIMARY, SECONDARY.'
-    );
+    ).toThrow('Incomplete multi-organization configuration');
   });
 
   it('prefers multi-org env config over single-org fallback env vars', async () => {

--- a/src/utils/backlogClientRegistry.test.ts
+++ b/src/utils/backlogClientRegistry.test.ts
@@ -1,7 +1,4 @@
-import { afterAll, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('backlog-js', () => ({
   Backlog: class Backlog {
@@ -28,26 +25,7 @@ import { getSpaceTool } from '../tools/getSpace.js';
 import { createBacklogClientRegistry } from './backlogClientRegistry.js';
 
 describe('createBacklogClientRegistry', () => {
-  const tempDirs: string[] = [];
-
-  function writeOrgConfig(
-    filename: string,
-    content: string
-  ): string {
-    const dir = mkdtempSync(join(tmpdir(), 'backlog-org-config-'));
-    tempDirs.push(dir);
-    const filepath = join(dir, filename);
-    writeFileSync(filepath, content);
-    return filepath;
-  }
-
-  afterAll(() => {
-    for (const dir of tempDirs) {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('uses single-org fallback env vars when multi-org config is absent', async () => {
+  it('uses single-org fallback env vars when multi-org env is absent', async () => {
     const registry = createBacklogClientRegistry({
       env: {
         BACKLOG_DOMAIN: 'single.backlog.com',
@@ -74,24 +52,13 @@ describe('createBacklogClientRegistry', () => {
   });
 
   it('routes a request to the selected organization', async () => {
-    const configPath = writeOrgConfig(
-      'organizations.yml',
-      [
-        'defaultOrg: primary',
-        'organizations:',
-        '  primary:',
-        '    domain: primary.backlog.com',
-        '    apiKey: primary-key',
-        '  secondary:',
-        '    domain: secondary.backlog.com',
-        '    apiKey: secondary-key',
-        '',
-      ].join('\n')
-    );
-
     const registry = createBacklogClientRegistry({
       env: {
-        BACKLOG_ORGANIZATIONS_CONFIG: configPath,
+        BACKLOG_DEFAULT_ORG: 'PRIMARY',
+        BACKLOG_ORG_PRIMARY_DOMAIN: 'primary.backlog.com',
+        BACKLOG_ORG_PRIMARY_API_KEY: 'primary-key',
+        BACKLOG_ORG_SECONDARY_DOMAIN: 'secondary.backlog.com',
+        BACKLOG_ORG_SECONDARY_API_KEY: 'secondary-key',
       },
     });
 
@@ -104,7 +71,7 @@ describe('createBacklogClientRegistry', () => {
       maxTokens: 5000,
     });
 
-    const result = await handler({ organization: 'secondary' }, {} as never);
+    const result = await handler({ organization: 'SECONDARY' }, {} as never);
     const content = result.content[0];
     expect(content.type).toBe('text');
     if (content.type === 'text') {
@@ -113,48 +80,41 @@ describe('createBacklogClientRegistry', () => {
     }
   });
 
-  it('requires organization when multiple organizations exist without a default', async () => {
-    const configPath = writeOrgConfig(
-      'organizations.yml',
-      [
-        'organizations:',
-        '  first:',
-        '    domain: first.backlog.com',
-        '    apiKey: first-key',
-        '  second:',
-        '    domain: second.backlog.com',
-        '    apiKey: second-key',
-        '',
-      ].join('\n')
-    );
-
+  it('uses the default organization when organization is omitted', async () => {
     const registry = createBacklogClientRegistry({
       env: {
-        BACKLOG_ORGANIZATIONS_CONFIG: configPath,
+        BACKLOG_DEFAULT_ORG: 'SECONDARY',
+        BACKLOG_ORG_PRIMARY_DOMAIN: 'primary.backlog.com',
+        BACKLOG_ORG_PRIMARY_API_KEY: 'primary-key',
+        BACKLOG_ORG_SECONDARY_DOMAIN: 'secondary.backlog.com',
+        BACKLOG_ORG_SECONDARY_API_KEY: 'secondary-key',
       },
     });
 
-    expect(() => registry.resolveClient()).toThrow(
-      'Multiple organizations are configured. Provide the organization field or configure defaultOrg.'
+    const tool = getSpaceTool(
+      registry.createScopedClient(),
+      createTranslationHelper()
     );
+    const handler = composeToolHandler(tool, {
+      useFields: false,
+      maxTokens: 5000,
+    });
+
+    const result = await handler({}, {} as never);
+    const content = result.content[0];
+    expect(content.type).toBe('text');
+    if (content.type === 'text') {
+      expect(content.text).toContain('secondary.backlog.com');
+      expect(content.text).toContain('secondary-key');
+    }
   });
 
   it('rejects unknown organizations', async () => {
-    const configPath = writeOrgConfig(
-      'organizations.yaml',
-      [
-        'defaultOrg: primary',
-        'organizations:',
-        '  primary:',
-        '    domain: primary.backlog.com',
-        '    apiKey: primary-key',
-        '',
-      ].join('\n')
-    );
-
     const registry = createBacklogClientRegistry({
       env: {
-        BACKLOG_ORGANIZATIONS_CONFIG: configPath,
+        BACKLOG_DEFAULT_ORG: 'PRIMARY',
+        BACKLOG_ORG_PRIMARY_DOMAIN: 'primary.backlog.com',
+        BACKLOG_ORG_PRIMARY_API_KEY: 'primary-key',
       },
     });
 
@@ -163,32 +123,74 @@ describe('createBacklogClientRegistry', () => {
     );
   });
 
-  it('fails clearly when the config file cannot be read', () => {
+  it('requires a default organization in multi-org mode', () => {
     expect(() =>
       createBacklogClientRegistry({
         env: {
-          BACKLOG_ORGANIZATIONS_CONFIG: '/tmp/does-not-exist-backlog-orgs.yml',
+          BACKLOG_ORG_PRIMARY_DOMAIN: 'primary.backlog.com',
+          BACKLOG_ORG_PRIMARY_API_KEY: 'primary-key',
         },
       })
     ).toThrow(
-      'BACKLOG_ORGANIZATIONS_CONFIG must point to a readable YAML config file:'
+      'BACKLOG_DEFAULT_ORG is required when using BACKLOG_ORG_<NAME>_DOMAIN and BACKLOG_ORG_<NAME>_API_KEY.'
     );
   });
 
-  it('rejects non-yaml config paths', () => {
-    const configPath = writeOrgConfig(
-      'organizations.json',
-      '{"defaultOrg":"primary","organizations":{"primary":{"domain":"primary.backlog.com","apiKey":"primary-key"}}}'
-    );
-
+  it('requires the default organization to match a configured organization', () => {
     expect(() =>
       createBacklogClientRegistry({
         env: {
-          BACKLOG_ORGANIZATIONS_CONFIG: configPath,
+          BACKLOG_DEFAULT_ORG: 'missing',
+          BACKLOG_ORG_PRIMARY_DOMAIN: 'primary.backlog.com',
+          BACKLOG_ORG_PRIMARY_API_KEY: 'primary-key',
         },
       })
     ).toThrow(
-      'BACKLOG_ORGANIZATIONS_CONFIG must point to a .yml or .yaml file.'
+      "BACKLOG_DEFAULT_ORG 'missing' does not match any configured organization. Use list_organizations to inspect available organizations."
     );
+  });
+
+  it('rejects incomplete multi-org definitions', () => {
+    expect(() =>
+      createBacklogClientRegistry({
+        env: {
+          BACKLOG_DEFAULT_ORG: 'PRIMARY',
+          BACKLOG_ORG_PRIMARY_DOMAIN: 'primary.backlog.com',
+          BACKLOG_ORG_SECONDARY_API_KEY: 'secondary-key',
+        },
+      })
+    ).toThrow(
+      'Each multi-organization config must define both BACKLOG_ORG_<NAME>_DOMAIN and BACKLOG_ORG_<NAME>_API_KEY. Incomplete organizations: PRIMARY, SECONDARY.'
+    );
+  });
+
+  it('prefers multi-org env config over single-org fallback env vars', async () => {
+    const registry = createBacklogClientRegistry({
+      env: {
+        BACKLOG_DOMAIN: 'single.backlog.com',
+        BACKLOG_API_KEY: 'single-key',
+        BACKLOG_DEFAULT_ORG: 'PRIMARY',
+        BACKLOG_ORG_PRIMARY_DOMAIN: 'primary.backlog.com',
+        BACKLOG_ORG_PRIMARY_API_KEY: 'primary-key',
+      },
+    });
+
+    const tool = getSpaceTool(
+      registry.createScopedClient(),
+      createTranslationHelper()
+    );
+    const handler = composeToolHandler(tool, {
+      useFields: false,
+      maxTokens: 5000,
+    });
+
+    const result = await handler({}, {} as never);
+    const content = result.content[0];
+    expect(content.type).toBe('text');
+    if (content.type === 'text') {
+      expect(content.text).toContain('primary.backlog.com');
+      expect(content.text).toContain('primary-key');
+      expect(content.text).not.toContain('single.backlog.com');
+    }
   });
 });

--- a/src/utils/backlogClientRegistry.test.ts
+++ b/src/utils/backlogClientRegistry.test.ts
@@ -1,0 +1,194 @@
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+vi.mock('backlog-js', () => ({
+  Backlog: class Backlog {
+    host: string;
+    apiKey: string;
+
+    constructor({ host, apiKey }: { host: string; apiKey: string }) {
+      this.host = host;
+      this.apiKey = apiKey;
+    }
+
+    async getSpace() {
+      return {
+        host: this.host,
+        apiKey: this.apiKey,
+      };
+    }
+  },
+}));
+
+import { createTranslationHelper } from '../createTranslationHelper.js';
+import { composeToolHandler } from '../handlers/builders/composeToolHandler.js';
+import { getSpaceTool } from '../tools/getSpace.js';
+import { createBacklogClientRegistry } from './backlogClientRegistry.js';
+
+describe('createBacklogClientRegistry', () => {
+  const tempDirs: string[] = [];
+
+  function writeOrgConfig(
+    filename: string,
+    content: string
+  ): string {
+    const dir = mkdtempSync(join(tmpdir(), 'backlog-org-config-'));
+    tempDirs.push(dir);
+    const filepath = join(dir, filename);
+    writeFileSync(filepath, content);
+    return filepath;
+  }
+
+  afterAll(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses single-org fallback env vars when multi-org config is absent', async () => {
+    const registry = createBacklogClientRegistry({
+      env: {
+        BACKLOG_DOMAIN: 'single.backlog.com',
+        BACKLOG_API_KEY: 'single-key',
+      },
+    });
+
+    const tool = getSpaceTool(
+      registry.createScopedClient(),
+      createTranslationHelper()
+    );
+    const handler = composeToolHandler(tool, {
+      useFields: false,
+      maxTokens: 5000,
+    });
+
+    const result = await handler({}, {} as never);
+    const content = result.content[0];
+    expect(content.type).toBe('text');
+    if (content.type === 'text') {
+      expect(content.text).toContain('single.backlog.com');
+      expect(content.text).toContain('single-key');
+    }
+  });
+
+  it('routes a request to the selected organization', async () => {
+    const configPath = writeOrgConfig(
+      'organizations.yml',
+      [
+        'defaultOrg: primary',
+        'organizations:',
+        '  primary:',
+        '    domain: primary.backlog.com',
+        '    apiKey: primary-key',
+        '  secondary:',
+        '    domain: secondary.backlog.com',
+        '    apiKey: secondary-key',
+        '',
+      ].join('\n')
+    );
+
+    const registry = createBacklogClientRegistry({
+      env: {
+        BACKLOG_ORGANIZATIONS_CONFIG: configPath,
+      },
+    });
+
+    const tool = getSpaceTool(
+      registry.createScopedClient(),
+      createTranslationHelper()
+    );
+    const handler = composeToolHandler(tool, {
+      useFields: false,
+      maxTokens: 5000,
+    });
+
+    const result = await handler({ organization: 'secondary' }, {} as never);
+    const content = result.content[0];
+    expect(content.type).toBe('text');
+    if (content.type === 'text') {
+      expect(content.text).toContain('secondary.backlog.com');
+      expect(content.text).toContain('secondary-key');
+    }
+  });
+
+  it('requires organization when multiple organizations exist without a default', async () => {
+    const configPath = writeOrgConfig(
+      'organizations.yml',
+      [
+        'organizations:',
+        '  first:',
+        '    domain: first.backlog.com',
+        '    apiKey: first-key',
+        '  second:',
+        '    domain: second.backlog.com',
+        '    apiKey: second-key',
+        '',
+      ].join('\n')
+    );
+
+    const registry = createBacklogClientRegistry({
+      env: {
+        BACKLOG_ORGANIZATIONS_CONFIG: configPath,
+      },
+    });
+
+    expect(() => registry.resolveClient()).toThrow(
+      'Multiple organizations are configured. Provide the organization field or configure defaultOrg.'
+    );
+  });
+
+  it('rejects unknown organizations', async () => {
+    const configPath = writeOrgConfig(
+      'organizations.yaml',
+      [
+        'defaultOrg: primary',
+        'organizations:',
+        '  primary:',
+        '    domain: primary.backlog.com',
+        '    apiKey: primary-key',
+        '',
+      ].join('\n')
+    );
+
+    const registry = createBacklogClientRegistry({
+      env: {
+        BACKLOG_ORGANIZATIONS_CONFIG: configPath,
+      },
+    });
+
+    expect(() => registry.resolveClient('missing')).toThrow(
+      "Unknown organization 'missing'. Use list_organizations to inspect available organizations."
+    );
+  });
+
+  it('fails clearly when the config file cannot be read', () => {
+    expect(() =>
+      createBacklogClientRegistry({
+        env: {
+          BACKLOG_ORGANIZATIONS_CONFIG: '/tmp/does-not-exist-backlog-orgs.yml',
+        },
+      })
+    ).toThrow(
+      'BACKLOG_ORGANIZATIONS_CONFIG must point to a readable YAML config file:'
+    );
+  });
+
+  it('rejects non-yaml config paths', () => {
+    const configPath = writeOrgConfig(
+      'organizations.json',
+      '{"defaultOrg":"primary","organizations":{"primary":{"domain":"primary.backlog.com","apiKey":"primary-key"}}}'
+    );
+
+    expect(() =>
+      createBacklogClientRegistry({
+        env: {
+          BACKLOG_ORGANIZATIONS_CONFIG: configPath,
+        },
+      })
+    ).toThrow(
+      'BACKLOG_ORGANIZATIONS_CONFIG must point to a .yml or .yaml file.'
+    );
+  });
+});

--- a/src/utils/backlogClientRegistry.test.ts
+++ b/src/utils/backlogClientRegistry.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+import { composeToolHandler } from '../handlers/builders/composeToolHandler.js';
+import { getSpaceTool } from '../tools/getSpace.js';
+import { createBacklogClientRegistry } from './backlogClientRegistry.js';
 
 vi.mock('backlog-js', () => ({
   Backlog: class Backlog {
@@ -18,11 +22,6 @@ vi.mock('backlog-js', () => ({
     }
   },
 }));
-
-import { createTranslationHelper } from '../createTranslationHelper.js';
-import { composeToolHandler } from '../handlers/builders/composeToolHandler.js';
-import { getSpaceTool } from '../tools/getSpace.js';
-import { createBacklogClientRegistry } from './backlogClientRegistry.js';
 
 describe('createBacklogClientRegistry', () => {
   it('uses single-org fallback env vars when multi-org env is absent', async () => {

--- a/src/utils/backlogClientRegistry.ts
+++ b/src/utils/backlogClientRegistry.ts
@@ -59,7 +59,16 @@ export function createBacklogClientRegistry(
       }
       return client;
     },
-    createScopedClient: () => createBacklogClientProxy(() => client),
+    createScopedClient: () =>
+      createBacklogClientProxy(() => {
+        const organization = getCurrentOrganization();
+        if (organization && organization !== defaultName) {
+          throw new Error(
+            `Unknown organization '${organization}'. Use list_organizations to inspect available organizations.`
+          );
+        }
+        return client;
+      }),
     listOrganizations: () => [info],
     getDefaultOrganization: () => defaultName,
   };

--- a/src/utils/backlogClientRegistry.ts
+++ b/src/utils/backlogClientRegistry.ts
@@ -1,5 +1,4 @@
 import { Backlog } from 'backlog-js';
-import * as backlogjs from 'backlog-js';
 import { getCurrentOrganization } from './backlogOrganizationContext.js';
 
 export type BacklogOrganizationInfo = {
@@ -43,7 +42,7 @@ export function createBacklogClientRegistry(
   }
 
   const defaultName = 'default';
-  const client = new backlogjs.Backlog({ host: domain, apiKey });
+  const client = new Backlog({ host: domain, apiKey });
 
   const info: BacklogOrganizationInfo = {
     name: defaultName,
@@ -140,9 +139,9 @@ function createMultiOrganizationRegistryFromEnv(
     ([name, config]) => {
       clients.set(
         name,
-        new backlogjs.Backlog({
-          host: config.domain,
-          apiKey: config.apiKey,
+        new Backlog({
+          host: config.domain as string,
+          apiKey: config.apiKey as string,
         })
       );
 

--- a/src/utils/backlogClientRegistry.ts
+++ b/src/utils/backlogClientRegistry.ts
@@ -1,0 +1,235 @@
+import { Backlog } from 'backlog-js';
+import * as backlogjs from 'backlog-js';
+import { cosmiconfigSync } from 'cosmiconfig';
+import { extname } from 'node:path';
+import { z } from 'zod';
+import { getCurrentOrganization } from './backlogOrganizationContext.js';
+
+const organizationSchema = z.object({
+  domain: z.string().min(1),
+  apiKey: z.string().min(1),
+});
+
+const organizationsConfigSchema = z.object({
+  defaultOrg: z.string().min(1).optional(),
+  organizations: z.record(z.string().min(1), organizationSchema),
+});
+
+export type BacklogOrganizationInfo = {
+  name: string;
+  domain: string;
+  isDefault: boolean;
+};
+
+export type BacklogClientResolver = (organization?: string) => Backlog;
+
+export type BacklogClientRegistry = {
+  resolveClient: BacklogClientResolver;
+  createScopedClient: () => Backlog;
+  listOrganizations: () => BacklogOrganizationInfo[];
+  getDefaultOrganization: () => string | undefined;
+};
+
+type RegistryInput = {
+  env?: NodeJS.ProcessEnv;
+};
+
+export function createBacklogClientRegistry(
+  input: RegistryInput = {}
+): BacklogClientRegistry {
+  const env = input.env ?? process.env;
+  const configuredPath = env.BACKLOG_ORGANIZATIONS_CONFIG;
+
+  if (configuredPath != null && configuredPath.trim().length > 0) {
+    return createMultiOrganizationRegistryFromPath(configuredPath);
+  }
+
+  const domain = env.BACKLOG_DOMAIN;
+  const apiKey = env.BACKLOG_API_KEY;
+
+  if (!domain || !apiKey) {
+    throw new Error(
+      'Either BACKLOG_ORGANIZATIONS_CONFIG (path to a YAML config file) or both BACKLOG_DOMAIN and BACKLOG_API_KEY are required.'
+    );
+  }
+
+  const defaultName = 'default';
+  const client = new backlogjs.Backlog({ host: domain, apiKey });
+
+  const info: BacklogOrganizationInfo = {
+    name: defaultName,
+    domain,
+    isDefault: true,
+  };
+
+  return {
+    resolveClient: (organization?: string) => {
+      if (organization && organization !== defaultName) {
+        throw new Error(
+          `Unknown organization '${organization}'. Use list_organizations to inspect available organizations.`
+        );
+      }
+      return client;
+    },
+    createScopedClient: () => createBacklogClientProxy(() => client),
+    listOrganizations: () => [info],
+    getDefaultOrganization: () => defaultName,
+  };
+}
+
+function createMultiOrganizationRegistryFromPath(
+  configPath: string
+): BacklogClientRegistry {
+  const extension = extname(configPath).toLowerCase();
+  if (extension !== '.yml' && extension !== '.yaml') {
+    throw new Error(
+      'BACKLOG_ORGANIZATIONS_CONFIG must point to a .yml or .yaml file.'
+    );
+  }
+
+  const explorer = cosmiconfigSync('backlog-mcp-server');
+
+  let loadedConfig: unknown;
+
+  try {
+    const result = explorer.load(configPath);
+    loadedConfig = result?.config;
+  } catch (error) {
+    throw new Error(
+      `BACKLOG_ORGANIZATIONS_CONFIG must point to a readable YAML config file: ${(error as Error).message}`
+    );
+  }
+
+  if (loadedConfig == null) {
+    throw new Error(
+      `BACKLOG_ORGANIZATIONS_CONFIG did not load any configuration from '${configPath}'.`
+    );
+  }
+
+  const parsed = organizationsConfigSchema.safeParse(loadedConfig);
+
+  if (!parsed.success) {
+    throw new Error(
+      `Organization config at '${configPath}' is invalid: ${parsed.error.issues
+        .map((issue) => issue.message)
+        .join(', ')}`
+    );
+  }
+
+  const organizations = Object.entries(parsed.data.organizations);
+
+  if (organizations.length === 0) {
+    throw new Error(
+      `Organization config at '${configPath}' must define at least one organization.`
+    );
+  }
+
+  if (
+    parsed.data.defaultOrg &&
+    !(parsed.data.defaultOrg in parsed.data.organizations)
+  ) {
+    throw new Error(
+      `Organization config at '${configPath}' declares defaultOrg '${parsed.data.defaultOrg}' that does not exist in organizations.`
+    );
+  }
+
+  const clients = new Map<string, Backlog>();
+  const organizationInfo = organizations.map(([name, config]) => {
+    clients.set(
+      name,
+      new backlogjs.Backlog({ host: config.domain, apiKey: config.apiKey })
+    );
+
+    return {
+      name,
+      domain: config.domain,
+      isDefault: name === parsed.data.defaultOrg,
+    };
+  });
+
+  const defaultOrganization =
+    parsed.data.defaultOrg ?? (organizationInfo.length === 1
+      ? organizationInfo[0].name
+      : undefined);
+
+  return {
+    resolveClient: (organization?: string) => {
+      const orgName = organization ?? defaultOrganization;
+
+      if (!orgName) {
+        throw new Error(
+          'Multiple organizations are configured. Provide the organization field or configure defaultOrg.'
+        );
+      }
+
+      const client = clients.get(orgName);
+
+      if (!client) {
+        throw new Error(
+          `Unknown organization '${orgName}'. Use list_organizations to inspect available organizations.`
+        );
+      }
+
+      return client;
+    },
+    createScopedClient: () =>
+      createBacklogClientProxy(() => {
+        const organization = getCurrentOrganization();
+        return organization === undefined
+          ? resolveDefaultClient(clients, defaultOrganization)
+          : resolveKnownClient(clients, organization);
+      }),
+    listOrganizations: () =>
+      organizationInfo.map((organization) => ({
+        ...organization,
+        isDefault: organization.name === defaultOrganization,
+      })),
+    getDefaultOrganization: () => defaultOrganization,
+  };
+}
+
+function resolveDefaultClient(
+  clients: Map<string, Backlog>,
+  defaultOrganization: string | undefined
+): Backlog {
+  if (defaultOrganization) {
+    return resolveKnownClient(clients, defaultOrganization);
+  }
+
+  throw new Error(
+    'Multiple organizations are configured. Provide the organization field or configure defaultOrg.'
+  );
+}
+
+function resolveKnownClient(
+  clients: Map<string, Backlog>,
+  organization: string
+): Backlog {
+  const client = clients.get(organization);
+
+  if (!client) {
+    throw new Error(
+      `Unknown organization '${organization}'. Use list_organizations to inspect available organizations.`
+    );
+  }
+
+  return client;
+}
+
+function createBacklogClientProxy(resolveClient: () => Backlog): Backlog {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        const client = resolveClient();
+        const value = Reflect.get(client as object, prop);
+
+        if (typeof value === 'function') {
+          return value.bind(client);
+        }
+
+        return value;
+      },
+    }
+  ) as Backlog;
+}

--- a/src/utils/backlogClientRegistry.ts
+++ b/src/utils/backlogClientRegistry.ts
@@ -66,6 +66,11 @@ export function createBacklogClientRegistry(
   };
 }
 
+type ValidatedOrganizationConfig = {
+  domain: string;
+  apiKey: string;
+};
+
 function createMultiOrganizationRegistryFromEnv(
   env: Environment
 ): BacklogClientRegistry | undefined {
@@ -98,12 +103,17 @@ function createMultiOrganizationRegistryFromEnv(
 
   const invalidOrganizations = Array.from(organizations.entries())
     .filter(([, config]) => !config.domain || !config.apiKey)
-    .map(([organization]) => organization)
+    .map(([organization, config]) => {
+      const missing = [];
+      if (!config.domain) missing.push(`BACKLOG_ORG_${organization}_DOMAIN`);
+      if (!config.apiKey) missing.push(`BACKLOG_ORG_${organization}_API_KEY`);
+      return `${organization} (missing: ${missing.join(', ')})`;
+    })
     .sort();
 
   if (invalidOrganizations.length > 0) {
     throw new Error(
-      `Each multi-organization config must define both BACKLOG_ORG_<NAME>_DOMAIN and BACKLOG_ORG_<NAME>_API_KEY. Incomplete organizations: ${invalidOrganizations.join(', ')}.`
+      `Incomplete multi-organization configuration. ${invalidOrganizations.join('; ')}`
     );
   }
 
@@ -121,19 +131,24 @@ function createMultiOrganizationRegistryFromEnv(
   }
 
   const clients = new Map<string, Backlog>();
-  const organizationInfo = Array.from(organizations.entries()).map(
+  // At this point, all organizations have been validated to have both domain and apiKey
+  const validatedOrganizations = organizations as Map<
+    string,
+    ValidatedOrganizationConfig
+  >;
+  const organizationInfo = Array.from(validatedOrganizations.entries()).map(
     ([name, config]) => {
       clients.set(
         name,
         new backlogjs.Backlog({
-          host: config.domain as string,
-          apiKey: config.apiKey as string,
+          host: config.domain,
+          apiKey: config.apiKey,
         })
       );
 
       return {
         name,
-        domain: config.domain as string,
+        domain: config.domain,
         isDefault: name === defaultOrganization,
       };
     }

--- a/src/utils/backlogClientRegistry.ts
+++ b/src/utils/backlogClientRegistry.ts
@@ -206,7 +206,7 @@ function createBacklogClientProxy(resolveClient: () => Backlog): Backlog {
     {
       get(_target, prop) {
         const client = resolveClient();
-        const value = Reflect.get(client as object, prop);
+        const value = Reflect.get(client, prop);
 
         if (typeof value === 'function') {
           return value.bind(client);

--- a/src/utils/backlogClientRegistry.ts
+++ b/src/utils/backlogClientRegistry.ts
@@ -69,10 +69,7 @@ export function createBacklogClientRegistry(
 function createMultiOrganizationRegistryFromEnv(
   env: Environment
 ): BacklogClientRegistry | undefined {
-  const organizations = new Map<
-    string,
-    { domain?: string; apiKey?: string }
-  >();
+  const organizations = new Map<string, { domain?: string; apiKey?: string }>();
   let hasMultiOrgKeys = false;
 
   for (const [key, value] of Object.entries(env)) {

--- a/src/utils/backlogClientRegistry.ts
+++ b/src/utils/backlogClientRegistry.ts
@@ -17,8 +17,10 @@ export type BacklogClientRegistry = {
   getDefaultOrganization: () => string | undefined;
 };
 
+type Environment = Record<string, string | undefined>;
+
 type RegistryInput = {
-  env?: NodeJS.ProcessEnv;
+  env?: Environment;
 };
 
 export function createBacklogClientRegistry(
@@ -65,7 +67,7 @@ export function createBacklogClientRegistry(
 }
 
 function createMultiOrganizationRegistryFromEnv(
-  env: NodeJS.ProcessEnv
+  env: Environment
 ): BacklogClientRegistry | undefined {
   const organizations = new Map<
     string,

--- a/src/utils/backlogClientRegistry.ts
+++ b/src/utils/backlogClientRegistry.ts
@@ -1,19 +1,6 @@
 import { Backlog } from 'backlog-js';
 import * as backlogjs from 'backlog-js';
-import { cosmiconfigSync } from 'cosmiconfig';
-import { extname } from 'node:path';
-import { z } from 'zod';
 import { getCurrentOrganization } from './backlogOrganizationContext.js';
-
-const organizationSchema = z.object({
-  domain: z.string().min(1),
-  apiKey: z.string().min(1),
-});
-
-const organizationsConfigSchema = z.object({
-  defaultOrg: z.string().min(1).optional(),
-  organizations: z.record(z.string().min(1), organizationSchema),
-});
 
 export type BacklogOrganizationInfo = {
   name: string;
@@ -38,10 +25,10 @@ export function createBacklogClientRegistry(
   input: RegistryInput = {}
 ): BacklogClientRegistry {
   const env = input.env ?? process.env;
-  const configuredPath = env.BACKLOG_ORGANIZATIONS_CONFIG;
+  const multiOrgRegistry = createMultiOrganizationRegistryFromEnv(env);
 
-  if (configuredPath != null && configuredPath.trim().length > 0) {
-    return createMultiOrganizationRegistryFromPath(configuredPath);
+  if (multiOrgRegistry) {
+    return multiOrgRegistry;
   }
 
   const domain = env.BACKLOG_DOMAIN;
@@ -49,7 +36,7 @@ export function createBacklogClientRegistry(
 
   if (!domain || !apiKey) {
     throw new Error(
-      'Either BACKLOG_ORGANIZATIONS_CONFIG (path to a YAML config file) or both BACKLOG_DOMAIN and BACKLOG_API_KEY are required.'
+      'Configure either BACKLOG_ORG_<NAME>_DOMAIN and BACKLOG_ORG_<NAME>_API_KEY with BACKLOG_DEFAULT_ORG, or both BACKLOG_DOMAIN and BACKLOG_API_KEY.'
     );
   }
 
@@ -77,128 +64,103 @@ export function createBacklogClientRegistry(
   };
 }
 
-function createMultiOrganizationRegistryFromPath(
-  configPath: string
-): BacklogClientRegistry {
-  const extension = extname(configPath).toLowerCase();
-  if (extension !== '.yml' && extension !== '.yaml') {
+function createMultiOrganizationRegistryFromEnv(
+  env: NodeJS.ProcessEnv
+): BacklogClientRegistry | undefined {
+  const organizations = new Map<
+    string,
+    { domain?: string; apiKey?: string }
+  >();
+  let hasMultiOrgKeys = false;
+
+  for (const [key, value] of Object.entries(env)) {
+    const match = /^BACKLOG_ORG_(.+)_(DOMAIN|API_KEY)$/.exec(key);
+    if (!match) {
+      continue;
+    }
+
+    hasMultiOrgKeys = true;
+
+    const [, organization, field] = match;
+    const config = organizations.get(organization) ?? {};
+
+    if (field === 'DOMAIN') {
+      config.domain = value;
+    } else {
+      config.apiKey = value;
+    }
+
+    organizations.set(organization, config);
+  }
+
+  if (!hasMultiOrgKeys) {
+    return undefined;
+  }
+
+  const invalidOrganizations = Array.from(organizations.entries())
+    .filter(([, config]) => !config.domain || !config.apiKey)
+    .map(([organization]) => organization)
+    .sort();
+
+  if (invalidOrganizations.length > 0) {
     throw new Error(
-      'BACKLOG_ORGANIZATIONS_CONFIG must point to a .yml or .yaml file.'
+      `Each multi-organization config must define both BACKLOG_ORG_<NAME>_DOMAIN and BACKLOG_ORG_<NAME>_API_KEY. Incomplete organizations: ${invalidOrganizations.join(', ')}.`
     );
   }
 
-  const explorer = cosmiconfigSync('backlog-mcp-server');
-
-  let loadedConfig: unknown;
-
-  try {
-    const result = explorer.load(configPath);
-    loadedConfig = result?.config;
-  } catch (error) {
+  if (organizations.size === 0) {
     throw new Error(
-      `BACKLOG_ORGANIZATIONS_CONFIG must point to a readable YAML config file: ${(error as Error).message}`
+      'No valid multi-organization configuration was found. Define BACKLOG_ORG_<NAME>_DOMAIN and BACKLOG_ORG_<NAME>_API_KEY pairs.'
     );
   }
 
-  if (loadedConfig == null) {
+  const defaultOrganization = env.BACKLOG_DEFAULT_ORG;
+  if (!defaultOrganization) {
     throw new Error(
-      `BACKLOG_ORGANIZATIONS_CONFIG did not load any configuration from '${configPath}'.`
-    );
-  }
-
-  const parsed = organizationsConfigSchema.safeParse(loadedConfig);
-
-  if (!parsed.success) {
-    throw new Error(
-      `Organization config at '${configPath}' is invalid: ${parsed.error.issues
-        .map((issue) => issue.message)
-        .join(', ')}`
-    );
-  }
-
-  const organizations = Object.entries(parsed.data.organizations);
-
-  if (organizations.length === 0) {
-    throw new Error(
-      `Organization config at '${configPath}' must define at least one organization.`
-    );
-  }
-
-  if (
-    parsed.data.defaultOrg &&
-    !(parsed.data.defaultOrg in parsed.data.organizations)
-  ) {
-    throw new Error(
-      `Organization config at '${configPath}' declares defaultOrg '${parsed.data.defaultOrg}' that does not exist in organizations.`
+      'BACKLOG_DEFAULT_ORG is required when using BACKLOG_ORG_<NAME>_DOMAIN and BACKLOG_ORG_<NAME>_API_KEY.'
     );
   }
 
   const clients = new Map<string, Backlog>();
-  const organizationInfo = organizations.map(([name, config]) => {
-    clients.set(
-      name,
-      new backlogjs.Backlog({ host: config.domain, apiKey: config.apiKey })
+  const organizationInfo = Array.from(organizations.entries()).map(
+    ([name, config]) => {
+      clients.set(
+        name,
+        new backlogjs.Backlog({
+          host: config.domain as string,
+          apiKey: config.apiKey as string,
+        })
+      );
+
+      return {
+        name,
+        domain: config.domain as string,
+        isDefault: name === defaultOrganization,
+      };
+    }
+  );
+
+  if (!clients.has(defaultOrganization)) {
+    throw new Error(
+      `BACKLOG_DEFAULT_ORG '${defaultOrganization}' does not match any configured organization. Use list_organizations to inspect available organizations.`
     );
-
-    return {
-      name,
-      domain: config.domain,
-      isDefault: name === parsed.data.defaultOrg,
-    };
-  });
-
-  const defaultOrganization =
-    parsed.data.defaultOrg ?? (organizationInfo.length === 1
-      ? organizationInfo[0].name
-      : undefined);
+  }
 
   return {
     resolveClient: (organization?: string) => {
       const orgName = organization ?? defaultOrganization;
-
-      if (!orgName) {
-        throw new Error(
-          'Multiple organizations are configured. Provide the organization field or configure defaultOrg.'
-        );
-      }
-
-      const client = clients.get(orgName);
-
-      if (!client) {
-        throw new Error(
-          `Unknown organization '${orgName}'. Use list_organizations to inspect available organizations.`
-        );
-      }
-
-      return client;
+      return resolveKnownClient(clients, orgName);
     },
     createScopedClient: () =>
       createBacklogClientProxy(() => {
         const organization = getCurrentOrganization();
         return organization === undefined
-          ? resolveDefaultClient(clients, defaultOrganization)
+          ? resolveKnownClient(clients, defaultOrganization)
           : resolveKnownClient(clients, organization);
       }),
-    listOrganizations: () =>
-      organizationInfo.map((organization) => ({
-        ...organization,
-        isDefault: organization.name === defaultOrganization,
-      })),
+    listOrganizations: () => organizationInfo,
     getDefaultOrganization: () => defaultOrganization,
   };
-}
-
-function resolveDefaultClient(
-  clients: Map<string, Backlog>,
-  defaultOrganization: string | undefined
-): Backlog {
-  if (defaultOrganization) {
-    return resolveKnownClient(clients, defaultOrganization);
-  }
-
-  throw new Error(
-    'Multiple organizations are configured. Provide the organization field or configure defaultOrg.'
-  );
 }
 
 function resolveKnownClient(

--- a/src/utils/backlogOrganizationContext.ts
+++ b/src/utils/backlogOrganizationContext.ts
@@ -1,0 +1,14 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const organizationStorage = new AsyncLocalStorage<string | undefined>();
+
+export function runWithOrganization<T>(
+  organization: string | undefined,
+  fn: () => Promise<T>
+): Promise<T> {
+  return organizationStorage.run(organization, fn);
+}
+
+export function getCurrentOrganization(): string | undefined {
+  return organizationStorage.getStore();
+}


### PR DESCRIPTION
## Summary

This PR adds multi-organization support to the Backlog MCP server using environment-variable configuration.

It keeps the existing single-organization setup as a fallback, lets callers choose a target organization per tool call, and adds a discovery tool so MCP clients can inspect the configured organizations.

## What Changed

- add env-based multi-organization configuration via `BACKLOG_ORG_<NAME>_DOMAIN`, `BACKLOG_ORG_<NAME>_API_KEY`, and `BACKLOG_DEFAULT_ORG`
- keep `BACKLOG_DOMAIN` / `BACKLOG_API_KEY` as the single-organization fallback
- replace the single global Backlog client setup with a client registry that resolves the correct client per request
- add request-scoped organization routing so normal tools can safely execute against the selected organization
- extend normal tool schemas with an optional `organization` field
- add a new `list_organizations` dynamic tool for organization discovery
- validate incomplete or invalid organization configuration with clearer startup/runtime errors
- document the feature in `README.md`, `README.ja.md`, and `.env.example`
- add tests for routing, fallback behavior, validation, and organization discovery

## Configuration

Configure one env pair per organization and set a default:

```bash
BACKLOG_DEFAULT_ORG=COMPANY_A
BACKLOG_ORG_COMPANY_A_DOMAIN=company-a.backlog.com
BACKLOG_ORG_COMPANY_A_API_KEY=your-company-a-api-key
BACKLOG_ORG_COMPANY_B_DOMAIN=company-b.backlog.com
BACKLOG_ORG_COMPANY_B_API_KEY=your-company-b-api-key
```

This also works when the variables are supplied through an MCP client `env` block, for example:

```json
{
  "env": {
    "BACKLOG_DEFAULT_ORG": "COMPANY_A",
    "BACKLOG_ORG_COMPANY_A_DOMAIN": "company-a.backlog.com",
    "BACKLOG_ORG_COMPANY_A_API_KEY": "your-company-a-api-key",
    "BACKLOG_ORG_COMPANY_B_DOMAIN": "company-b.backlog.com",
    "BACKLOG_ORG_COMPANY_B_API_KEY": "your-company-b-api-key"
  }
}
```

If no multi-organization env vars are set, the server falls back to the existing single-organization configuration:

```bash
BACKLOG_DOMAIN=your-domain.backlog.com
BACKLOG_API_KEY=your-api-key
```

## MCP Behavior

- normal tools now accept an optional `organization` field
- when `organization` is omitted, the configured default organization is used
- if multi-org env vars are present and `BACKLOG_DEFAULT_ORG` is missing or invalid, the server fails fast
- `list_organizations` returns the configured organization names, domains, and default status
- unknown organization names are rejected with an explicit error message

## Tests

- `npm test`
- `npm run typecheck:all`
