### PR TITLE
fix(ci): pin npm to 11.5.1 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           cache: 'npm'
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- `npm install -g npm@latest` が GitHub Actions runner 上で `MODULE_NOT_FOUND: promise-retry` を出してリリースワークフローを壊していたため、npm のバージョンを固定する
- 11.5.1 は OIDC trusted publishing を満たす最小バージョン（このステップの目的）

## 背景
`@latest` を使っていると、npm の新バージョンがリリースされるたびに runner バンドル版 npm からの自己アップグレード中のファイル置換タイミングで壊れることがある。バージョン固定でこの依存を断つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)