### PR TITLE
refactor: prefer const over let where possible

### DIFF
--- a/src/handlers/builders/composeToolHandler.ts
+++ b/src/handlers/builders/composeToolHandler.ts
@@ -39,14 +39,12 @@ export function composeToolHandler(
   tool.schema = extendSchema(tool.schema, fieldDesc);
 
   // Step 2: Compose
-  let handler: ComposedHandler = wrapWithErrorHandling(
+  const baseHandler: ComposedHandler = wrapWithErrorHandling(
     wrapWithOrganizationContext(tool.handler),
     errorHandler
   );
 
-  if (useFields) {
-    handler = wrapWithFieldPicking(handler);
-  }
+  const handler = useFields ? wrapWithFieldPicking(baseHandler) : baseHandler;
 
   return wrapWithToolResult(wrapWithTokenLimit(handler, maxTokens));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,12 +127,9 @@ const transHelper = createTranslationHelper();
 
 const maxTokens = argv.maxTokens;
 const prefix = argv.prefix;
-let enabledToolsets = argv.enableToolsets as string[];
-
-// If dynamic toolsets are enabled, remove "all" to allow for selective enabling via commands
-if (argv.dynamicToolsets) {
-  enabledToolsets = enabledToolsets.filter((a) => a !== 'all');
-}
+const enabledToolsets = argv.dynamicToolsets
+  ? (argv.enableToolsets as string[]).filter((a) => a !== 'all')
+  : (argv.enableToolsets as string[]);
 
 const mcpOption = { useFields: useFields, maxTokens, prefix };
 


### PR DESCRIPTION
## Summary
- `src/index.ts`: 三項演算子を使い `enabledToolsets` を `const` に変更
- `src/handlers/builders/composeToolHandler.ts`: `baseHandler` と `handler` に分離し `const` に変更

## Test plan
- [x] 全テスト通過確認済み (331 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)