### PR TITLE
feat: add mcpb manifest for Desktop Extensions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ coverage/
 tmp/
 temp/
 
+# MCPB bundle
+*.mcpb
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,47 @@
+{
+  "manifest_version": "0.2",
+  "name": "backlog-mcp-server",
+  "version": "0.11.0",
+  "description": "backlog mcp server",
+  "author": {
+    "name": "nulab"
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "server/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": [
+        "${__dirname}/server/index.js"
+      ],
+      "env": {
+        "BACKLOG_API_KEY": "${backlog_api_key}",
+        "BACKLOG_DOMAIN": "${backlog_domain}"
+      }
+    }
+  },
+  "user_config": {
+    "backlog_api_key": {
+      "type": "string",
+      "title": "Backlog API Key",
+      "description": "API key for authenticating with Backlog",
+      "required": true,
+      "sensitive": true
+    },
+    "backlog_domain": {
+      "type": "string",
+      "title": "Backlog Domain",
+      "description": "Your Backlog domain (e.g. your-space.backlog.com)",
+      "required": true,
+      "sensitive": false
+    }
+  },
+  "keywords": [
+    "backlog"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nulab/backlog-mcp-server.git"
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -8,15 +8,15 @@
   },
   "server": {
     "type": "node",
-    "entry_point": "server/index.js",
+    "entry_point": "build/index.js",
     "mcp_config": {
       "command": "node",
       "args": [
-        "${__dirname}/server/index.js"
+        "${__dirname}/build/index.js"
       ],
       "env": {
-        "BACKLOG_API_KEY": "${backlog_api_key}",
-        "BACKLOG_DOMAIN": "${backlog_domain}"
+        "BACKLOG_API_KEY": "${user_config.backlog_api_key}",
+        "BACKLOG_DOMAIN": "${user_config.backlog_domain}"
       }
     }
   },


### PR DESCRIPTION
## Summary

- Add `manifest.json` for mcpb bundling, enabling one-click installation in Claude Desktop and other compatible clients
- Define `user_config` for `BACKLOG_API_KEY` (sensitive) and `BACKLOG_DOMAIN`
- Add `*.mcpb` to `.gitignore`

## Related

- #110

## Test plan

- [x] generate .mcpb file by the command `mcpb pack`
- [x] install the `.mcpb` to Claude Desktop desktop and connect to backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)