### PR TITLE
feat: add post_space_attachment, delete_issue_comment, delete_issue_attachment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ MCP_TRANSPORT=http MCP_HTTP_PORT=3333 node build/index.js
 
 Environment variables (CLI flags override when both are set):
 
-| Variable | Description |
-| -------- | ----------- |
-| `MCP_TRANSPORT` | `stdio` (default) or `http` |
-| `MCP_HTTP_HOST` | Bind address (default `127.0.0.1`) |
-| `MCP_HTTP_PORT` | Port (default `3333`) |
-| `MCP_HTTP_PATH` | URL path (default `/mcp`) |
-| `MCP_HTTP_JSON_RESPONSE` | `true` to prefer JSON responses over SSE when supported |
+| Variable                 | Description                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------ |
+| `MCP_TRANSPORT`          | `stdio` (default) or `http`                                                                |
+| `MCP_HTTP_HOST`          | Bind address (default `127.0.0.1`)                                                         |
+| `MCP_HTTP_PORT`          | Port (default `3333`)                                                                      |
+| `MCP_HTTP_PATH`          | URL path (default `/mcp`)                                                                  |
+| `MCP_HTTP_JSON_RESPONSE` | `true` to prefer JSON responses over SSE when supported                                    |
 | `MCP_HTTP_ALLOWED_HOSTS` | Comma-separated allowed `Host` values when binding to `0.0.0.0` (DNS rebinding protection) |
 
 ## Tool Configuration
@@ -230,6 +230,7 @@ Tools for managing Backlog space settings and general information.
 - `get_space`: Returns information about the Backlog space.
 - `get_users`: Returns list of users in the Backlog space.
 - `get_myself`: Returns information about the authenticated user.
+- `post_space_attachment`: Uploads a file to Backlog space. Supports local file path or base64-encoded content.
 
 ### Toolset: `project`
 
@@ -253,6 +254,8 @@ Tools for managing issues, their comments, and related items like priorities, ca
 - `delete_issue`: Deletes an issue.
 - `get_issue_comments`: Returns list of comments for an issue.
 - `add_issue_comment`: Adds a comment to an issue.
+- `delete_issue_comment`: Deletes a comment from an issue.
+- `delete_issue_attachment`: Deletes an attachment from an issue.
 - `get_priorities`: Returns list of priorities.
 - `get_categories`: Returns list of categories for a project.
 - `get_custom_fields`: Returns list of custom fields for a project.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,9 @@ export default [
         URL: 'readonly',
         Request: 'readonly',
         Response: 'readonly',
+        FormData: 'readonly',
+        Blob: 'readonly',
+        File: 'readonly',
       },
     },
     plugins: {

--- a/src/tools/deleteIssueAttachment.test.ts
+++ b/src/tools/deleteIssueAttachment.test.ts
@@ -1,0 +1,71 @@
+import { deleteIssueAttachmentTool } from './deleteIssueAttachment.js';
+import { vi, describe, it, expect } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+
+describe('deleteIssueAttachmentTool', () => {
+  const mockBacklog: Partial<Backlog> = {
+    deleteIssueAttachment: vi.fn<() => Promise<any>>().mockResolvedValue({
+      id: 200,
+      name: 'screenshot.png',
+      size: 12345,
+      createdUser: {
+        id: 1,
+        userId: 'admin',
+        name: 'Admin User',
+        roleType: 1,
+        lang: 'en',
+        mailAddress: 'admin@example.com',
+        lastLoginTime: '2023-01-01T00:00:00Z',
+      },
+      created: '2023-01-01T00:00:00Z',
+    }),
+  };
+
+  const mockTranslationHelper = createTranslationHelper();
+  const tool = deleteIssueAttachmentTool(
+    mockBacklog as Backlog,
+    mockTranslationHelper
+  );
+
+  it('returns deleted attachment info', async () => {
+    const result = await tool.handler({
+      issueKey: 'TEST-1',
+      attachmentId: 200,
+    });
+
+    if (Array.isArray(result)) {
+      throw new Error('Unexpected array result');
+    }
+
+    expect(result.id).toBe(200);
+    expect(result.name).toBe('screenshot.png');
+  });
+
+  it('calls backlog.deleteIssueAttachment with issue key and attachment ID as string', async () => {
+    await tool.handler({
+      issueKey: 'TEST-1',
+      attachmentId: 200,
+    });
+
+    expect(mockBacklog.deleteIssueAttachment).toHaveBeenCalledWith(
+      'TEST-1',
+      '200'
+    );
+  });
+
+  it('calls backlog.deleteIssueAttachment with issue ID', async () => {
+    await tool.handler({
+      issueId: 10,
+      attachmentId: 200,
+    });
+
+    expect(mockBacklog.deleteIssueAttachment).toHaveBeenCalledWith(10, '200');
+  });
+
+  it('throws if neither issueId nor issueKey is provided', async () => {
+    await expect(tool.handler({ attachmentId: 200 } as any)).rejects.toThrow(
+      Error
+    );
+  });
+});

--- a/src/tools/deleteIssueAttachment.ts
+++ b/src/tools/deleteIssueAttachment.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { Backlog } from 'backlog-js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+import { TranslationHelper } from '../createTranslationHelper.js';
+import { IssueFileInfoSchema } from '../types/zod/backlogOutputDefinition.js';
+import { resolveIdOrKey } from '../utils/resolveIdOrKey.js';
+
+const deleteIssueAttachmentSchema = buildToolSchema((t) => ({
+  issueId: z
+    .number()
+    .optional()
+    .describe(
+      t(
+        'TOOL_DELETE_ISSUE_ATTACHMENT_ISSUE_ID',
+        'The numeric ID of the issue (e.g., 12345)'
+      )
+    ),
+  issueKey: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_DELETE_ISSUE_ATTACHMENT_ISSUE_KEY',
+        "The key of the issue (e.g., 'PROJ-123')"
+      )
+    ),
+  attachmentId: z
+    .number()
+    .describe(
+      t(
+        'TOOL_DELETE_ISSUE_ATTACHMENT_ATTACHMENT_ID',
+        'The ID of the attachment'
+      )
+    ),
+}));
+
+export const deleteIssueAttachmentTool = (
+  backlog: Backlog,
+  { t }: TranslationHelper
+): ToolDefinition<
+  ReturnType<typeof deleteIssueAttachmentSchema>,
+  (typeof IssueFileInfoSchema)['shape']
+> => {
+  return {
+    name: 'delete_issue_attachment',
+    description: t(
+      'TOOL_DELETE_ISSUE_ATTACHMENT_DESCRIPTION',
+      'Deletes an attachment from an issue'
+    ),
+    schema: z.object(deleteIssueAttachmentSchema(t)),
+    outputSchema: IssueFileInfoSchema,
+    handler: async ({ issueId, issueKey, attachmentId }) => {
+      const result = resolveIdOrKey('issue', { id: issueId, key: issueKey }, t);
+      if (!result.ok) {
+        throw result.error;
+      }
+      return backlog.deleteIssueAttachment(result.value, String(attachmentId));
+    },
+  };
+};

--- a/src/tools/deleteIssueComment.test.ts
+++ b/src/tools/deleteIssueComment.test.ts
@@ -1,0 +1,73 @@
+import { deleteIssueCommentTool } from './deleteIssueComment.js';
+import { vi, describe, it, expect } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+
+describe('deleteIssueCommentTool', () => {
+  const mockBacklog: Partial<Backlog> = {
+    deleteIssueComment: vi.fn<() => Promise<any>>().mockResolvedValue({
+      id: 100,
+      projectId: 1,
+      issueId: 10,
+      content: 'Deleted comment',
+      changeLog: [],
+      createdUser: {
+        id: 1,
+        userId: 'admin',
+        name: 'Admin User',
+        roleType: 1,
+        lang: 'en',
+        mailAddress: 'admin@example.com',
+        lastLoginTime: '2023-01-01T00:00:00Z',
+      },
+      created: '2023-01-01T00:00:00Z',
+      updated: '2023-01-01T00:00:00Z',
+      stars: [],
+      notifications: [],
+    }),
+  };
+
+  const mockTranslationHelper = createTranslationHelper();
+  const tool = deleteIssueCommentTool(
+    mockBacklog as Backlog,
+    mockTranslationHelper
+  );
+
+  it('returns deleted comment', async () => {
+    const result = await tool.handler({
+      issueKey: 'TEST-1',
+      commentId: 100,
+    });
+
+    if (Array.isArray(result)) {
+      throw new Error('Unexpected array result');
+    }
+
+    expect(result.id).toBe(100);
+    expect(result.content).toBe('Deleted comment');
+  });
+
+  it('calls backlog.deleteIssueComment with issue key and comment ID', async () => {
+    await tool.handler({
+      issueKey: 'TEST-1',
+      commentId: 100,
+    });
+
+    expect(mockBacklog.deleteIssueComment).toHaveBeenCalledWith('TEST-1', 100);
+  });
+
+  it('calls backlog.deleteIssueComment with issue ID', async () => {
+    await tool.handler({
+      issueId: 10,
+      commentId: 100,
+    });
+
+    expect(mockBacklog.deleteIssueComment).toHaveBeenCalledWith(10, 100);
+  });
+
+  it('throws if neither issueId nor issueKey is provided', async () => {
+    await expect(tool.handler({ commentId: 100 } as any)).rejects.toThrow(
+      Error
+    );
+  });
+});

--- a/src/tools/deleteIssueComment.ts
+++ b/src/tools/deleteIssueComment.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import { Backlog } from 'backlog-js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+import { TranslationHelper } from '../createTranslationHelper.js';
+import { IssueCommentSchema } from '../types/zod/backlogOutputDefinition.js';
+import { resolveIdOrKey } from '../utils/resolveIdOrKey.js';
+
+const deleteIssueCommentSchema = buildToolSchema((t) => ({
+  issueId: z
+    .number()
+    .optional()
+    .describe(
+      t(
+        'TOOL_DELETE_ISSUE_COMMENT_ISSUE_ID',
+        'The numeric ID of the issue (e.g., 12345)'
+      )
+    ),
+  issueKey: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_DELETE_ISSUE_COMMENT_ISSUE_KEY',
+        "The key of the issue (e.g., 'PROJ-123')"
+      )
+    ),
+  commentId: z
+    .number()
+    .describe(
+      t('TOOL_DELETE_ISSUE_COMMENT_COMMENT_ID', 'The ID of the comment')
+    ),
+}));
+
+export const deleteIssueCommentTool = (
+  backlog: Backlog,
+  { t }: TranslationHelper
+): ToolDefinition<
+  ReturnType<typeof deleteIssueCommentSchema>,
+  (typeof IssueCommentSchema)['shape']
+> => {
+  return {
+    name: 'delete_issue_comment',
+    description: t(
+      'TOOL_DELETE_ISSUE_COMMENT_DESCRIPTION',
+      'Deletes a comment from an issue'
+    ),
+    schema: z.object(deleteIssueCommentSchema(t)),
+    outputSchema: IssueCommentSchema,
+    handler: async ({ issueId, issueKey, commentId }) => {
+      const result = resolveIdOrKey('issue', { id: issueId, key: issueKey }, t);
+      if (!result.ok) {
+        throw result.error;
+      }
+      return backlog.deleteIssueComment(result.value, commentId);
+    },
+  };
+};

--- a/src/tools/postSpaceAttachment.test.ts
+++ b/src/tools/postSpaceAttachment.test.ts
@@ -1,0 +1,135 @@
+import { postSpaceAttachmentTool } from './postSpaceAttachment.js';
+import { vi, describe, it, expect, beforeEach, afterAll } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+import { Buffer } from 'node:buffer';
+import { writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('postSpaceAttachmentTool', () => {
+  const mockPostSpaceAttachment = vi
+    .fn<(form: FormData) => Promise<any>>()
+    .mockResolvedValue({
+      id: 1,
+      name: 'screenshot.png',
+      size: 12345,
+    });
+
+  const mockBacklog: Partial<Backlog> = {
+    postSpaceAttachment: mockPostSpaceAttachment,
+  };
+
+  const mockTranslationHelper = createTranslationHelper();
+  const tool = postSpaceAttachmentTool(
+    mockBacklog as Backlog,
+    mockTranslationHelper
+  );
+
+  beforeEach(() => {
+    mockPostSpaceAttachment.mockClear();
+  });
+
+  describe('with fileContent (base64)', () => {
+    it('returns uploaded file info', async () => {
+      const result = await tool.handler({
+        fileName: 'screenshot.png',
+        fileContent: 'aGVsbG8=', // "hello" in base64
+      });
+
+      if (Array.isArray(result)) {
+        throw new Error('Unexpected array result');
+      }
+
+      expect(result.id).toBe(1);
+      expect(result.name).toBe('screenshot.png');
+      expect(result.size).toBe(12345);
+    });
+
+    it('calls backlog.postSpaceAttachment with FormData containing the file', async () => {
+      await tool.handler({
+        fileName: 'test.txt',
+        fileContent: 'dGVzdA==', // "test" in base64
+      });
+
+      expect(mockPostSpaceAttachment).toHaveBeenCalledTimes(1);
+      const form = mockPostSpaceAttachment.mock.calls[0][0] as FormData;
+      expect(form).toBeInstanceOf(FormData);
+      const file = form.get('file') as File;
+      expect(file).toBeInstanceOf(File);
+      expect(file.name).toBe('test.txt');
+    });
+
+    it('correctly decodes base64 content', async () => {
+      await tool.handler({
+        fileName: 'data.bin',
+        fileContent: 'AQID', // [1, 2, 3] in base64
+      });
+
+      const form = mockPostSpaceAttachment.mock.calls[0][0] as FormData;
+      const file = form.get('file') as File;
+      const arrayBuffer = await file.arrayBuffer();
+      const bytes = new Uint8Array(arrayBuffer);
+      expect(Array.from(bytes)).toEqual([1, 2, 3]);
+    });
+
+    it('throws if fileName is missing with fileContent', async () => {
+      await expect(tool.handler({ fileContent: 'aGVsbG8=' })).rejects.toThrow(
+        'fileName is required when using fileContent'
+      );
+    });
+  });
+
+  describe('with filePath', () => {
+    const testDir = join(tmpdir(), 'backlog-mcp-test');
+    const testFilePath = join(testDir, 'test-image.png');
+    const testContent = Buffer.from([0x89, 0x50, 0x4e, 0x47]); // PNG magic bytes
+
+    beforeEach(() => {
+      mkdirSync(testDir, { recursive: true });
+      writeFileSync(testFilePath, testContent);
+    });
+
+    afterAll(() => {
+      rmSync(testDir, { recursive: true, force: true });
+    });
+
+    it('reads file from disk and uploads', async () => {
+      await tool.handler({ filePath: testFilePath });
+
+      expect(mockPostSpaceAttachment).toHaveBeenCalledTimes(1);
+      const form = mockPostSpaceAttachment.mock.calls[0][0] as FormData;
+      const file = form.get('file') as File;
+      expect(file).toBeInstanceOf(File);
+      expect(file.name).toBe('test-image.png');
+      const arrayBuffer = await file.arrayBuffer();
+      const bytes = new Uint8Array(arrayBuffer);
+      expect(Array.from(bytes)).toEqual([0x89, 0x50, 0x4e, 0x47]);
+    });
+
+    it('uses custom fileName over basename when provided', async () => {
+      await tool.handler({
+        filePath: testFilePath,
+        fileName: 'custom-name.png',
+      });
+
+      const form = mockPostSpaceAttachment.mock.calls[0][0] as FormData;
+      const file = form.get('file') as File;
+      expect(file.name).toBe('custom-name.png');
+    });
+
+    it('throws if filePath does not exist', async () => {
+      await expect(
+        tool.handler({ filePath: '/nonexistent/path/file.png' })
+      ).rejects.toThrow('File not found: /nonexistent/path/file.png');
+    });
+  });
+
+  describe('validation', () => {
+    it('throws if neither filePath nor fileContent is provided', async () => {
+      await expect(tool.handler({})).rejects.toThrow(
+        'Either filePath or fileContent must be provided'
+      );
+    });
+  });
+});

--- a/src/tools/postSpaceAttachment.ts
+++ b/src/tools/postSpaceAttachment.ts
@@ -1,0 +1,98 @@
+import { readFile, access } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { Buffer } from 'node:buffer';
+import { Backlog } from 'backlog-js';
+import { z } from 'zod';
+import { TranslationHelper } from '../createTranslationHelper.js';
+import { SpaceAttachmentSchema } from '../types/zod/backlogOutputDefinition.js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+
+const postSpaceAttachmentSchema = buildToolSchema((t) => ({
+  filePath: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_POST_SPACE_ATTACHMENT_FILE_PATH',
+        'Absolute path to a local file to upload. When provided, fileContent and fileName are optional (fileName defaults to the basename of the path).'
+      )
+    ),
+  fileName: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_POST_SPACE_ATTACHMENT_FILE_NAME',
+        'The name of the file to upload (e.g., "screenshot.png"). Required when using fileContent; optional when using filePath (defaults to basename).'
+      )
+    ),
+  fileContent: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_POST_SPACE_ATTACHMENT_FILE_CONTENT',
+        'The file content encoded as a base64 string. Either filePath or fileContent must be provided.'
+      )
+    ),
+}));
+
+export const postSpaceAttachmentTool = (
+  backlog: Backlog,
+  { t }: TranslationHelper
+): ToolDefinition<
+  ReturnType<typeof postSpaceAttachmentSchema>,
+  (typeof SpaceAttachmentSchema)['shape']
+> => {
+  return {
+    name: 'post_space_attachment',
+    description: t(
+      'TOOL_POST_SPACE_ATTACHMENT_DESCRIPTION',
+      'Uploads a file to Backlog space. Returns the attachment ID which can be used when creating or updating issues, comments, or wiki pages. The uploaded file will be deleted after it has been attached, or an hour later if not attached. Provide either filePath (for local files) or fileContent (base64-encoded string).'
+    ),
+    schema: z.object(postSpaceAttachmentSchema(t)),
+    outputSchema: SpaceAttachmentSchema,
+    handler: async ({ filePath, fileName, fileContent }) => {
+      if (!filePath && !fileContent) {
+        throw new Error(
+          t(
+            'TOOL_POST_SPACE_ATTACHMENT_INPUT_REQUIRED',
+            'Either filePath or fileContent must be provided'
+          )
+        );
+      }
+
+      let buffer: Buffer;
+      let name: string;
+
+      if (filePath) {
+        await access(filePath).catch(() => {
+          throw new Error(
+            t(
+              'TOOL_POST_SPACE_ATTACHMENT_FILE_NOT_FOUND',
+              `File not found: ${filePath}`
+            )
+          );
+        });
+        buffer = await readFile(filePath);
+        name = fileName ?? basename(filePath);
+      } else {
+        if (!fileName) {
+          throw new Error(
+            t(
+              'TOOL_POST_SPACE_ATTACHMENT_NAME_REQUIRED',
+              'fileName is required when using fileContent'
+            )
+          );
+        }
+        buffer = Buffer.from(fileContent!, 'base64');
+        name = fileName;
+      }
+
+      const blob = new Blob([buffer]);
+      const form = new FormData();
+      form.append('file', blob, name);
+      return backlog.postSpaceAttachment(form);
+    },
+  };
+};

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -9,6 +9,8 @@ import { addPullRequestCommentTool } from './addPullRequestComment.js';
 import { addWikiTool } from './addWiki.js';
 import { updateWikiTool } from './updateWiki.js';
 import { countIssuesTool } from './countIssues.js';
+import { deleteIssueAttachmentTool } from './deleteIssueAttachment.js';
+import { deleteIssueCommentTool } from './deleteIssueComment.js';
 import { deleteIssueTool } from './deleteIssue.js';
 import { deleteProjectTool } from './deleteProject.js';
 import { getCategoriesTool } from './getCategories.js';
@@ -32,6 +34,7 @@ import { getPullRequestsCountTool } from './getPullRequestsCount.js';
 import { getResolutionsTool } from './getResolutions.js';
 import { getSpaceTool } from './getSpace.js';
 import { getSpaceActivitiesTool } from './getSpaceActivities.js';
+import { postSpaceAttachmentTool } from './postSpaceAttachment.js';
 import { getUserStarsCountTool } from './getUserStarsCount.js';
 import { getUsersTool } from './getUsers.js';
 import { getUserRecentUpdatesTool } from './getUserRecentUpdates.js';
@@ -77,6 +80,7 @@ export const allTools = (
           getUserStarsCountTool(backlog, helper),
           getMyselfTool(backlog, helper),
           getUserRecentUpdatesTool(backlog, helper),
+          postSpaceAttachmentTool(backlog, helper),
         ],
       },
       {
@@ -105,6 +109,8 @@ export const allTools = (
           deleteIssueTool(backlog, helper),
           getIssueCommentsTool(backlog, helper),
           addIssueCommentTool(backlog, helper),
+          deleteIssueCommentTool(backlog, helper),
+          deleteIssueAttachmentTool(backlog, helper),
           getPrioritiesTool(backlog, helper),
           getCategoriesTool(backlog, helper),
           getCustomFieldsTool(backlog, helper),

--- a/src/types/zod/backlogOutputDefinition.ts
+++ b/src/types/zod/backlogOutputDefinition.ts
@@ -118,6 +118,12 @@ export const CategorySchema = z.object({
   displayOrder: z.number(),
 });
 
+export const SpaceAttachmentSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  size: z.number(),
+});
+
 export const IssueFileInfoSchema = z.object({
   id: z.number(),
   name: z.string(),


### PR DESCRIPTION
## Summary

Adds three tools that enable a complete attachment workflow and comment/attachment cleanup:

- **`post_space_attachment`** (space toolset) — Uploads a file to Backlog space. Supports local file path or base64-encoded content. Returns attachment ID for use with
`add_issue_comment` or `update_issue`.
- **`delete_issue_comment`** (issue toolset) — Deletes a comment from an issue.
- **`delete_issue_attachment`** (issue toolset) — Deletes an attachment from an issue.

### Motivation

We use this MCP server in our AI-assisted development workflow. When agents fix bugs, they need to attach evidence (screenshots, API response diffs) to Backlog issues. Currently the
server can create comments but cannot upload files or clean up outdated comments/attachments. These three tools close that gap.

All tools follow existing patterns (`resolveIdOrKey`, `buildToolSchema`, `TranslationHelper`, `outputSchema`).

## Test plan

- [x] `npm test` — all 347 tests pass (16 new)
- [x] `npm run lint` — clean
- [x] `npm run format` — clean
- [x] Tested full CRUD flow against real Backlog API