### PR TITLE
fix: allow string values in customFields for text and date fields

### DIFF
--- a/src/tools/addIssue.ts
+++ b/src/tools/addIssue.ts
@@ -80,10 +80,15 @@ const addIssueSchema = buildToolSchema((t) => ({
             )
           ),
         value: z
-          .union([z.number(), z.array(z.number())])
+          .union([
+            z.string(),
+            z.number(),
+            z.array(z.string()),
+            z.array(z.number()),
+          ])
           .optional()
           .describe(
-            'The ID(s) of the custom field item. For single-select fields, provide a number. For multi-select fields, provide an array of numbers representing the selected item IDs.'
+            'Value of the custom field. For text/date fields, provide a string. For numeric fields, provide a number. For list fields, provide an array of strings or numbers.'
           ),
         otherValue: z
           .string()

--- a/src/tools/addIssue.ts
+++ b/src/tools/addIssue.ts
@@ -88,7 +88,10 @@ const addIssueSchema = buildToolSchema((t) => ({
           ])
           .optional()
           .describe(
-            'Value of the custom field. For text/date fields, provide a string. For numeric fields, provide a number. For list fields, provide an array of strings or numbers.'
+            t(
+              'TOOL_ADD_ISSUE_CUSTOM_FIELD_VALUE',
+              'Value of the custom field. For text/date fields, provide a string. For numeric fields, provide a number. For list fields, provide an array of strings or numbers.'
+            )
           ),
         otherValue: z
           .string()

--- a/src/tools/updateIssue.ts
+++ b/src/tools/updateIssue.ts
@@ -121,7 +121,10 @@ const updateIssueSchema = buildToolSchema((t) => ({
           ])
           .optional()
           .describe(
-            'Value of the custom field. For text/date fields, provide a string. For numeric fields, provide a number. For list fields, provide an array of strings or numbers.'
+            t(
+              'TOOL_UPDATE_ISSUE_CUSTOM_FIELD_VALUE',
+              'Value of the custom field. For text/date fields, provide a string. For numeric fields, provide a number. For list fields, provide an array of strings or numbers.'
+            )
           ),
         otherValue: z
           .string()

--- a/src/tools/updateIssue.ts
+++ b/src/tools/updateIssue.ts
@@ -113,10 +113,15 @@ const updateIssueSchema = buildToolSchema((t) => ({
             )
           ),
         value: z
-          .union([z.number(), z.array(z.number())])
+          .union([
+            z.string(),
+            z.number(),
+            z.array(z.string()),
+            z.array(z.number()),
+          ])
           .optional()
           .describe(
-            'The ID(s) of the custom field item. For single-select fields, provide a number. For multi-select fields, provide an array of numbers representing the selected item IDs.'
+            'Value of the custom field. For text/date fields, provide a string. For numeric fields, provide a number. For list fields, provide an array of strings or numbers.'
           ),
         otherValue: z
           .string()


### PR DESCRIPTION
## Summary

Allow string values in `customFields` for text and date field types.

## Problem

The `value` field in `customFields` only accepted `number | number[]`,
making it impossible to set values for text or date custom fields,
which require string values according to the Backlog API specification.

## Changes

- `src/tools/addIssue.ts`
  - Expanded `value` schema to accept `string | number | string[] | number[]`
  - Updated the MCP tool field description for `value` to document all supported value types
- `src/tools/updateIssue.ts`
  - Applied the same changes

## Test

- Manually verified on a local Docker container via the MCP tool that creating and updating issues with both string (date-type) and numeric custom field values work correctly
- No unit tests were added because the underlying logic already handles both `string` and `number` values identically, and all existing tests pass

Closes #118
