### PR TITLE
feat: replace dotenv with Node.js built-in process.loadEnvFile()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "backlog-js": "^0.16.0",
         "cosmiconfig": "^9.0.0",
-        "dotenv": "^16.5.0",
         "env-var": "^7.5.0",
         "graphql": "^16.11.0",
         "hono": "^4.12.18",
@@ -42,6 +41,9 @@
         "tsx": "^4.20.6",
         "typescript": "^5.8.3",
         "vitest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3307,6 +3309,7 @@
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "backlog-mcp-server": "./build/index.js"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -31,7 +34,6 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "backlog-js": "^0.16.0",
     "cosmiconfig": "^9.0.0",
-    "dotenv": "^16.5.0",
     "env-var": "^7.5.0",
     "graphql": "^16.11.0",
     "hono": "^4.12.18",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@
 // Licensed under the MIT License.
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import dotenv from 'dotenv';
 import { default as env } from 'env-var';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
@@ -42,7 +41,11 @@ process.on('unhandledRejection', (reason) => {
   process.exit(1);
 });
 
-dotenv.config();
+try {
+  process.loadEnvFile();
+} catch {
+  // .env file is optional
+}
 
 const oauthConfig = getBacklogOAuthConfig();
 


### PR DESCRIPTION
Closes #66

## Summary

- Replace `dotenv.config()` with `process.loadEnvFile()` (Node.js v21.7.0+)
- Remove `dotenv` from dependencies
- Add `"node": ">=22"` to `engines` field in `package.json`

## Notes

- `.env` file is optional: wrapped in try-catch to silently ignore missing file (same behavior as `dotenv.config()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)