### PR TITLE
docs: use pnpm instead of npm in Japanese README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -101,8 +101,8 @@ docker pull ghcr.io/nulab/backlog-mcp-server:latest
    ```bash
    git clone https://github.com/nulab/backlog-mcp-server.git
    cd backlog-mcp-server
-   npm install
-   npm run build
+   pnpm install
+   pnpm run build
    ```
 
 2. テンプレートから `.env` を作成し、必須の環境変数を設定します：
@@ -119,7 +119,7 @@ cp .env.example .env
 3. ローカルで起動します：
 
 ```bash
-npm run dev
+pnpm run dev
 ```
 
 4. MCPとして使用するJSONを設定します：
@@ -529,7 +529,7 @@ MAX_TOKENS=10000
 ### テストの実行
 
 ```bash
-npm test
+pnpm test
 ```
 
 ### 新しいツールの追加


### PR DESCRIPTION
## 概要

日本語版 README (`README.ja.md`) に残っていた `npm` コマンドを `pnpm` に置き換えました。

このプロジェクトはすでに pnpm へ移行済み（`packageManager: pnpm@9.15.9`、`preinstall: npx only-allow pnpm`、`pnpm-lock.yaml`、CI / Dockerfile / 英語 README すべて pnpm）でしたが、日本語 README だけ `npm` 表記が残っていたため、英語版に合わせて修正します。

## 変更内容

- `npm install` → `pnpm install`
- `npm run build` → `pnpm run build`
- `npm run dev` → `pnpm run dev`
- `npm test` → `pnpm test`

`npx github:nulab/...`（翻訳エクスポート用コマンド）は英語版 README と同様にそのまま残しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)