### PR TITLE
chore: enforce 3-day minimum release age for pnpm installs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=4320

--- a/package.json
+++ b/package.json
@@ -8,7 +8,14 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.4+sha512.8768be55200ae3f2226b6527fcca2687e14bc4e5f12d7721a0f25da3df47915177058648db4177baf348120fa0ba2752d8d8d93f6beaf1fe64ae18da8de961af",
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=22",
+      "onFail": "warn"
+    }
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump pnpm from `9.15.9` to `10.34.4` in `packageManager` (minimum version needed for the `minimumReleaseAge` feature)
- Add `.npmrc` with `minimum-release-age=4320` (3 days, in minutes) to block installing npm package versions published less than 3 days ago, as a supply-chain-attack mitigation
- Add `devEngines.runtime` for node `>=22` (advisory check, `onFail: warn`)

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds with pnpm 10.34.4, no lockfile drift
- [x] `pnpm run build` succeeds
- [x] `pnpm run test` — all 396 tests pass