### PR TITLE
fix: allow clearing array fields in update_issue with empty array

### DIFF
--- a/src/tools/updateIssue.test.ts
+++ b/src/tools/updateIssue.test.ts
@@ -168,6 +168,34 @@ describe('updateIssueTool', () => {
     );
   });
 
+  it('converts empty array fields to [""] so the Backlog API clears them', async () => {
+    await tool.handler({
+      issueKey: 'TEST-1',
+      categoryId: [],
+      milestoneId: [],
+      versionId: [],
+    });
+
+    expect(mockBacklog.patchIssue).toHaveBeenCalledWith('TEST-1', {
+      categoryId: [''],
+      milestoneId: [''],
+      versionId: [''],
+    });
+  });
+
+  it('leaves non-empty array fields untouched', async () => {
+    await tool.handler({
+      issueKey: 'TEST-1',
+      categoryId: [10, 20],
+      milestoneId: [],
+    });
+
+    expect(mockBacklog.patchIssue).toHaveBeenCalledWith('TEST-1', {
+      categoryId: [10, 20],
+      milestoneId: [''],
+    });
+  });
+
   it('transforms customFields that provide only otherValue during update', async () => {
     await tool.handler({
       issueKey: 'TEST-1',

--- a/src/tools/updateIssue.test.ts
+++ b/src/tools/updateIssue.test.ts
@@ -196,6 +196,19 @@ describe('updateIssueTool', () => {
     });
   });
 
+  it('does not convert non-clearable array fields (notifiedUserId, attachmentId)', async () => {
+    await tool.handler({
+      issueKey: 'TEST-1',
+      notifiedUserId: [],
+      attachmentId: [],
+    });
+
+    expect(mockBacklog.patchIssue).toHaveBeenCalledWith('TEST-1', {
+      notifiedUserId: [],
+      attachmentId: [],
+    });
+  });
+
   it('transforms customFields that provide only otherValue during update', async () => {
     await tool.handler({
       issueKey: 'TEST-1',

--- a/src/tools/updateIssue.ts
+++ b/src/tools/updateIssue.ts
@@ -150,6 +150,32 @@ const updateIssueSchema = buildToolSchema((t) => ({
     ),
 }));
 
+// Backlog API clears an array field (e.g. category/version/milestone) only when
+// the parameter is sent as `field[]=` (empty value). backlog-js serializes
+// params via qs with `arrayFormat: 'brackets'`, and an empty array `[]` produces
+// no query string at all, so the API silently ignores it. Converting `[]` to
+// `['']` makes qs emit `field[]=`, which the API interprets as "clear".
+const CLEARABLE_ARRAY_FIELDS = [
+  'categoryId',
+  'versionId',
+  'milestoneId',
+  'notifiedUserId',
+  'attachmentId',
+] as const;
+
+const clearEmptyArrayFields = <T extends Record<string, unknown>>(
+  params: T
+): T => {
+  const next: Record<string, unknown> = { ...params };
+  for (const field of CLEARABLE_ARRAY_FIELDS) {
+    const value = next[field];
+    if (Array.isArray(value) && value.length === 0) {
+      next[field] = [''];
+    }
+  }
+  return next as T;
+};
+
 export const updateIssueTool = (
   backlog: Backlog,
   { t }: TranslationHelper
@@ -173,7 +199,7 @@ export const updateIssueTool = (
       const customFieldPayload = customFieldsToPayload(customFields);
 
       const finalPayload = {
-        ...params,
+        ...clearEmptyArrayFields(params),
         ...customFieldPayload,
       };
       return backlog.patchIssue(result.value, finalPayload);

--- a/src/tools/updateIssue.ts
+++ b/src/tools/updateIssue.ts
@@ -66,15 +66,30 @@ const updateIssueSchema = buildToolSchema((t) => ({
   categoryId: z
     .array(z.number())
     .optional()
-    .describe(t('TOOL_UPDATE_ISSUE_CATEGORY_ID', 'Category IDs')),
+    .describe(
+      t(
+        'TOOL_UPDATE_ISSUE_CATEGORY_ID',
+        'Category IDs. Pass an empty array to clear all categories. Omit this field to leave the current categories unchanged.'
+      )
+    ),
   versionId: z
     .array(z.number())
     .optional()
-    .describe(t('TOOL_UPDATE_ISSUE_VERSION_ID', 'Version IDs')),
+    .describe(
+      t(
+        'TOOL_UPDATE_ISSUE_VERSION_ID',
+        'Version IDs. Pass an empty array to clear all versions. Omit this field to leave the current versions unchanged.'
+      )
+    ),
   milestoneId: z
     .array(z.number())
     .optional()
-    .describe(t('TOOL_UPDATE_ISSUE_MILESTONE_ID', 'Milestone IDs')),
+    .describe(
+      t(
+        'TOOL_UPDATE_ISSUE_MILESTONE_ID',
+        'Milestone IDs. Pass an empty array to clear all milestones. Omit this field to leave the current milestones unchanged.'
+      )
+    ),
   statusId: z
     .number()
     .optional()

--- a/src/tools/updateIssue.ts
+++ b/src/tools/updateIssue.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { Backlog } from 'backlog-js';
+import { Backlog, Option } from 'backlog-js';
 import { buildToolSchema, ToolDefinition } from '../types/tool.js';
 import { TranslationHelper } from '../createTranslationHelper.js';
 import { IssueSchema } from '../types/zod/backlogOutputDefinition.js';
@@ -150,22 +150,33 @@ const updateIssueSchema = buildToolSchema((t) => ({
     ),
 }));
 
-// Backlog API clears an array field (e.g. category/version/milestone) only when
+// Backlog API clears a stored array field (category/version/milestone) only when
 // the parameter is sent as `field[]=` (empty value). backlog-js serializes
 // params via qs with `arrayFormat: 'brackets'`, and an empty array `[]` produces
 // no query string at all, so the API silently ignores it. Converting `[]` to
 // `['']` makes qs emit `field[]=`, which the API interprets as "clear".
+//
+// Only these three are persistent, clearable array fields. notifiedUserId (a
+// one-off notification target) and attachmentId (attachments to add) are action
+// parameters, not stored state, so they are intentionally excluded.
 const CLEARABLE_ARRAY_FIELDS = [
   'categoryId',
   'versionId',
   'milestoneId',
-  'notifiedUserId',
-  'attachmentId',
 ] as const;
+
+type ClearableArrayField = (typeof CLEARABLE_ARRAY_FIELDS)[number];
+
+// The conversion replaces a numeric-id array with `['']`, so the return type
+// widens the clearable fields to also allow `['']`. Keeping the cast localized
+// here makes the intended type-unsafety visible instead of hiding it behind `T`.
+type WithClearedArrayFields<T> = Omit<T, ClearableArrayField> & {
+  [K in ClearableArrayField]?: T[K & keyof T] | [''];
+};
 
 const clearEmptyArrayFields = <T extends Record<string, unknown>>(
   params: T
-): T => {
+): WithClearedArrayFields<T> => {
   const next: Record<string, unknown> = { ...params };
   for (const field of CLEARABLE_ARRAY_FIELDS) {
     const value = next[field];
@@ -173,7 +184,7 @@ const clearEmptyArrayFields = <T extends Record<string, unknown>>(
       next[field] = [''];
     }
   }
-  return next as T;
+  return next as WithClearedArrayFields<T>;
 };
 
 export const updateIssueTool = (
@@ -202,7 +213,13 @@ export const updateIssueTool = (
         ...clearEmptyArrayFields(params),
         ...customFieldPayload,
       };
-      return backlog.patchIssue(result.value, finalPayload);
+      // The `['']` clear-sentinel is not representable in backlog-js's
+      // `number[]` param types, so cast at this single boundary. qs serializes
+      // it to `field[]=`, which the Backlog API accepts as "clear this field".
+      return backlog.patchIssue(
+        result.value,
+        finalPayload as Option.Issue.PatchIssueParams
+      );
     },
   };
 };


### PR DESCRIPTION
## 概要

`update_issue` で空配列(例 `categoryId: []`)を渡しても無視され、既存のカテゴリー/マイルストーン/バージョンを API 経由でクリアできない問題を修正します。

## 原因

backlog-js は内部で `qs.stringify(params, { arrayFormat: 'brackets' })` を使ってパラメータをシリアライズします。空配列 `[]` は **クエリ文字列を一切生成しません**(`categoryId[]=` すら出力されない)。そのため Backlog API に「クリア」の意図が伝わらず、既存値がそのまま残ります。

Backlog API で配列フィールドをクリアするには `field[]=`(空値)を送る必要があります。

```
qs.stringify({ categoryId: [] },   { arrayFormat: 'brackets' })  // => ""            (送信されない)
qs.stringify({ categoryId: [''] }, { arrayFormat: 'brackets' })  // => "categoryId[]="(クリアされる)
```

## 修正内容

`patchIssue` 呼び出し前に、クリア可能な配列フィールドの空配列を `['']` に変換し、backlog-js が `field[]=` を送るようにしました。空でない配列は変更しません。

対象は **保存される状態** を持つ3フィールドのみです:

| フィールド | 対象 | 理由 |
|---|---|---|
| `categoryId` | ✅ | 課題に保存される配列フィールド |
| `versionId` | ✅ | 同上 |
| `milestoneId` | ✅ | 同上 |
| `notifiedUserId` | ❌ | その更新1回限りの通知先。保存される状態ではない |
| `attachmentId` | ❌ | 追加する添付の指定。保存される状態ではない |

## 挙動の変更点(呼び出し側への影響)

**`categoryId: []` の意味が「無視」から「クリア」に変わります。** 呼び出し元が LLM である以上、「指定なし」のつもりで空配列が渡される可能性があるため、zod スキーマの `describe()` に両者の違いを明記しました。

- 空配列を渡す → クリアされる
- フィールド自体を省略する → 変更されない

翻訳は ENV / config によるインライン文字列のオーバーライド方式のため、別途 i18n リソースファイルの更新は不要です。

## 動作確認

実際の Backlog API に対して検証済み:

| 送信内容 | category / milestone |
|---|---|
| `categoryId[]=<id>` 他(セット) | Tori / Tori・Hiyoko |
| 無関係フィールドのみ更新 | Tori のまま(部分更新は維持) |
| **`categoryId[]=` `milestoneId[]=`(修正後の形)** | **空 = クリア成功** |

- `pnpm test` (updateIssue: 10 tests passing、クリア関連テスト3件を追加 / 全体 399 tests passing)
- `pnpm lint` / `prettier --check` / `tsc --noEmit` すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
