### PR TITLE
feat: add get_project_users tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Tools for managing projects, categories, custom fields, and issue types.
 - `get_project_list`: Returns list of projects.
 - `add_project`: Creates a new project.
 - `get_project`: Returns information about a specific project.
+- `get_project_users`: Returns list of users in a specific project.
 - `update_project`: Updates an existing project.
 - `delete_project`: Deletes a project.
 

--- a/src/tools/getProjectUsers.test.ts
+++ b/src/tools/getProjectUsers.test.ts
@@ -28,7 +28,10 @@ describe('getProjectUsersTool', () => {
   };
 
   const mockTranslationHelper = createTranslationHelper();
-  const tool = getProjectUsersTool(mockBacklog as Backlog, mockTranslationHelper);
+  const tool = getProjectUsersTool(
+    mockBacklog as Backlog,
+    mockTranslationHelper
+  );
 
   it('returns project users list', async () => {
     const result = await tool.handler({ projectId: 100 });

--- a/src/tools/getProjectUsers.test.ts
+++ b/src/tools/getProjectUsers.test.ts
@@ -1,0 +1,59 @@
+import { getProjectUsersTool } from './getProjectUsers.js';
+import { vi, describe, it, expect } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+
+describe('getProjectUsersTool', () => {
+  const mockBacklog: Partial<Backlog> = {
+    getProjectUsers: vi.fn<() => Promise<any>>().mockResolvedValue([
+      {
+        id: 1,
+        userId: 'admin',
+        name: 'Admin User',
+        roleType: 1,
+        lang: 'en',
+        mailAddress: 'admin@example.com',
+        lastLoginTime: '2023-01-01T00:00:00Z',
+      },
+      {
+        id: 2,
+        userId: 'user1',
+        name: 'Regular User',
+        roleType: 2,
+        lang: 'en',
+        mailAddress: 'user1@example.com',
+        lastLoginTime: '2023-01-02T00:00:00Z',
+      },
+    ]),
+  };
+
+  const mockTranslationHelper = createTranslationHelper();
+  const tool = getProjectUsersTool(mockBacklog as Backlog, mockTranslationHelper);
+
+  it('returns project users list', async () => {
+    const result = await tool.handler({ projectId: 100 });
+
+    if (!Array.isArray(result)) {
+      throw new Error('Unexpected array result');
+    }
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toContain('Admin User');
+    expect(result[1].name).toContain('Regular User');
+  });
+
+  it('calls backlog.getProjectUsers with the resolved project id', async () => {
+    await tool.handler({ projectId: 100 });
+
+    expect(mockBacklog.getProjectUsers).toHaveBeenCalledWith(100);
+  });
+
+  it('calls backlog.getProjectUsers with the project key', async () => {
+    await tool.handler({ projectKey: 'PROJECT' });
+
+    expect(mockBacklog.getProjectUsers).toHaveBeenCalledWith('PROJECT');
+  });
+
+  it('throws when neither projectId nor projectKey is provided', async () => {
+    await expect(tool.handler({})).rejects.toThrow();
+  });
+});

--- a/src/tools/getProjectUsers.ts
+++ b/src/tools/getProjectUsers.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+import { Backlog } from 'backlog-js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+import { TranslationHelper } from '../createTranslationHelper.js';
+import { UserSchema } from '../types/zod/backlogOutputDefinition.js';
+import { resolveIdOrKey } from '../utils/resolveIdOrKey.js';
+
+const getProjectUsersSchema = buildToolSchema((t) => ({
+  projectId: z
+    .number()
+    .optional()
+    .describe(
+      t(
+        'TOOL_GET_PROJECT_USERS_PROJECT_ID',
+        'The numeric ID of the project (e.g., 12345)'
+      )
+    ),
+  projectKey: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_GET_PROJECT_USERS_PROJECT_KEY',
+        "The key of the project (e.g., 'PROJECT')"
+      )
+    ),
+}));
+
+export const getProjectUsersTool = (
+  backlog: Backlog,
+  { t }: TranslationHelper
+): ToolDefinition<
+  ReturnType<typeof getProjectUsersSchema>,
+  (typeof UserSchema)['shape']
+> => {
+  return {
+    name: 'get_project_users',
+    description: t(
+      'TOOL_GET_PROJECT_USERS_DESCRIPTION',
+      'Returns list of users in a specific project'
+    ),
+    schema: z.object(getProjectUsersSchema(t)),
+    outputSchema: UserSchema,
+    importantFields: ['userId', 'name', 'roleType', 'lang'],
+    handler: async ({ projectId, projectKey }) => {
+      const result = resolveIdOrKey(
+        'project',
+        { id: projectId, key: projectKey },
+        t
+      );
+      if (!result.ok) {
+        throw result.error;
+      }
+      return backlog.getProjectUsers(result.value);
+    },
+  };
+};

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -25,6 +25,7 @@ import { getNotificationsCountTool } from './getNotificationsCount.js';
 import { getPrioritiesTool } from './getPriorities.js';
 import { getProjectTool } from './getProject.js';
 import { getProjectListTool } from './getProjectList.js';
+import { getProjectUsersTool } from './getProjectUsers.js';
 import { getPullRequestTool } from './getPullRequest.js';
 import { getPullRequestCommentsTool } from './getPullRequestComments.js';
 import { getPullRequestsTool } from './getPullRequests.js';
@@ -88,6 +89,7 @@ export const allTools = (
           getProjectListTool(backlog, helper),
           addProjectTool(backlog, helper),
           getProjectTool(backlog, helper),
+          getProjectUsersTool(backlog, helper),
           updateProjectTool(backlog, helper),
           deleteProjectTool(backlog, helper),
         ],


### PR DESCRIPTION
## Summary

Adds a new MCP tool `get_project_users` for the Backlog [`GET /projects/:projectIdOrKey/users`](https://developer.nulab.com/docs/backlog/api/2/get-project-user-list/) endpoint. It accepts a `projectId` or `projectKey`, resolves it via `resolveIdOrKey`, and returns the list of users in that project.

Closes #146

## Changes
- `src/tools/getProjectUsers.ts` — new tool, returns `UserSchema[]` via `backlog.getProjectUsers()`
- `src/tools/getProjectUsers.test.ts` — tests for id/key resolution and the missing-arg error
- `src/tools/tools.ts` — registered the tool in the `project` toolset
- `README.md` — documented the tool

## Note
The API documents an optional `excludeGroupMembers` query parameter, but the `backlog-js` client's `getProjectUsers(projectIdOrKey)` signature doesn't accept it, so it's not exposed here.

## Testing
- `npx tsc --noEmit` — clean
- `npx vitest run` — 402 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)