### PR TITLE
fix(ci): disable pnpm git-checks during release-it publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,3 +65,7 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # release-it bumps package.json/CHANGELOG.md before invoking `pnpm publish`,
+          # leaving the working tree intentionally dirty at publish time. Disable pnpm's
+          # git-checks for this step only so publish doesn't abort with ERR_PNPM_GIT_UNCLEAN.
+          NPM_CONFIG_GIT_CHECKS: false


### PR DESCRIPTION
## Problem

The `0.13.0` release run failed at the publish step:

```
ERR_PNPM_GIT_UNCLEAN  Unclean working tree. Commit or stash changes first.
```

## Root cause

release-it's execution order is *bump files → publish → git commit/tag*. Because publish is configured to use pnpm (`"publishPackageManager": "pnpm"` in `.release-it.json`), `pnpm publish` runs its **own** git clean-tree check at a point where release-it has *intentionally* left `package.json` and `CHANGELOG.md` modified. release-it's `"skipChecks": true` only suppresses release-it's own npm checks — it does not propagate `--no-git-checks` to the underlying pnpm command, so the check can never pass in this flow.

## Fix

Set `NPM_CONFIG_GIT_CHECKS=false` as an env var **only on the release-it step**. This is the tightest scope: the working tree is expected to be dirty during release-it's publish, while local/manual `pnpm publish` keeps its safeguard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)