### PR TITLE
feat: add update_comment tool for editing issue comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Tools for managing issues, their comments, and related items like priorities, ca
 - `delete_issue`: Deletes an issue.
 - `get_issue_comments`: Returns list of comments for an issue.
 - `add_issue_comment`: Adds a comment to an issue.
+- `update_comment`: Updates a comment on an issue.
 - `get_priorities`: Returns list of priorities.
 - `get_categories`: Returns list of categories for a project.
 - `get_custom_fields`: Returns list of custom fields for a project.

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Tools for managing issues, their comments, and related items like priorities, ca
 - `delete_issue`: Deletes an issue.
 - `get_issue_comments`: Returns list of comments for an issue.
 - `add_issue_comment`: Adds a comment to an issue.
-- `update_comment`: Updates a comment on an issue.
+- `update_issue_comment`: Updates a comment on an issue.
 - `get_priorities`: Returns list of priorities.
 - `get_categories`: Returns list of categories for a project.
 - `get_custom_fields`: Returns list of custom fields for a project.

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -48,6 +48,7 @@ import { getWikisCountTool } from './getWikisCount.js';
 import { markNotificationAsReadTool } from './markNotificationAsRead.js';
 import { resetUnreadNotificationCountTool } from './resetUnreadNotificationCount.js';
 import { updateIssueTool } from './updateIssue.js';
+import { updateIssueCommentTool } from './updateIssueComment.js';
 import { updateProjectTool } from './updateProject.js';
 import { updatePullRequestTool } from './updatePullRequest.js';
 import { updatePullRequestCommentTool } from './updatePullRequestComment.js';
@@ -107,6 +108,7 @@ export const allTools = (
           deleteIssueTool(backlog, helper),
           getIssueCommentsTool(backlog, helper),
           addIssueCommentTool(backlog, helper),
+          updateIssueCommentTool(backlog, helper),
           getPrioritiesTool(backlog, helper),
           getCategoriesTool(backlog, helper),
           getCustomFieldsTool(backlog, helper),

--- a/src/tools/updateIssueComment.test.ts
+++ b/src/tools/updateIssueComment.test.ts
@@ -1,5 +1,5 @@
 import { updateIssueCommentTool } from './updateIssueComment.js';
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import type { Backlog } from 'backlog-js';
 import { createTranslationHelper } from '../createTranslationHelper.js';
 
@@ -32,6 +32,10 @@ describe('updateIssueCommentTool', () => {
     mockBacklog as Backlog,
     mockTranslationHelper
   );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it('returns updated comment', async () => {
     const result = await tool.handler({

--- a/src/tools/updateIssueComment.test.ts
+++ b/src/tools/updateIssueComment.test.ts
@@ -1,0 +1,79 @@
+import { updateIssueCommentTool } from './updateIssueComment.js';
+import { vi, describe, it, expect } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+
+describe('updateIssueCommentTool', () => {
+  const mockBacklog: Partial<Backlog> = {
+    patchIssueComment: vi.fn<() => Promise<any>>().mockResolvedValue({
+      id: 3,
+      projectId: 1,
+      issueId: 1,
+      content: 'Updated comment content',
+      changeLog: [],
+      createdUser: {
+        id: 1,
+        userId: 'admin',
+        name: 'Admin User',
+        roleType: 1,
+        lang: 'en',
+        mailAddress: 'admin@example.com',
+        lastLoginTime: '2023-01-01T00:00:00Z',
+      },
+      created: '2023-01-01T00:00:00Z',
+      updated: '2023-01-02T00:00:00Z',
+      stars: [],
+      notifications: [],
+    }),
+  };
+
+  const mockTranslationHelper = createTranslationHelper();
+  const tool = updateIssueCommentTool(
+    mockBacklog as Backlog,
+    mockTranslationHelper
+  );
+
+  it('returns updated comment', async () => {
+    const result = await tool.handler({
+      issueKey: 'TEST-1',
+      commentId: 3,
+      content: 'Updated comment content',
+    });
+
+    expect(result).toHaveProperty('content', 'Updated comment content');
+    expect(result).toHaveProperty('id', 3);
+  });
+
+  it('calls backlog.patchIssueComment with correct params when using issue key', async () => {
+    await tool.handler({
+      issueKey: 'TEST-1',
+      commentId: 3,
+      content: 'Updated comment content',
+    });
+
+    expect(mockBacklog.patchIssueComment).toHaveBeenCalledWith('TEST-1', 3, {
+      content: 'Updated comment content',
+    });
+  });
+
+  it('calls backlog.patchIssueComment with correct params when using issue ID', async () => {
+    await tool.handler({
+      issueId: 1,
+      commentId: 3,
+      content: 'Updated comment content via issueId',
+    });
+
+    expect(mockBacklog.patchIssueComment).toHaveBeenCalledWith(1, 3, {
+      content: 'Updated comment content via issueId',
+    });
+  });
+
+  it('throws an error if neither issueId nor issueKey is provided', async () => {
+    await expect(
+      tool.handler({
+        commentId: 3,
+        content: 'This should fail due to missing issue identifier',
+      } as any)
+    ).rejects.toThrow(Error);
+  });
+});

--- a/src/tools/updateIssueComment.ts
+++ b/src/tools/updateIssueComment.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { Backlog } from 'backlog-js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+import { TranslationHelper } from '../createTranslationHelper.js';
+import { IssueCommentSchema } from '../types/zod/backlogOutputDefinition.js';
+import { resolveIdOrKey } from '../utils/resolveIdOrKey.js';
+
+const updateIssueCommentSchema = buildToolSchema((t) => ({
+  issueId: z
+    .number()
+    .optional()
+    .describe(
+      t(
+        'TOOL_UPDATE_ISSUE_COMMENT_ISSUE_ID',
+        'The numeric ID of the issue (e.g., 12345)'
+      )
+    ),
+  issueKey: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_UPDATE_ISSUE_COMMENT_ISSUE_KEY',
+        "The key of the issue (e.g., 'PROJ-123')"
+      )
+    ),
+  commentId: z
+    .number()
+    .describe(t('TOOL_UPDATE_ISSUE_COMMENT_COMMENT_ID', 'Comment ID')),
+  content: z
+    .string()
+    .describe(t('TOOL_UPDATE_ISSUE_COMMENT_CONTENT', 'Comment content')),
+}));
+
+export const updateIssueCommentTool = (
+  backlog: Backlog,
+  { t }: TranslationHelper
+): ToolDefinition<
+  ReturnType<typeof updateIssueCommentSchema>,
+  (typeof IssueCommentSchema)['shape']
+> => {
+  return {
+    name: 'update_comment',
+    description: t(
+      'TOOL_UPDATE_ISSUE_COMMENT_DESCRIPTION',
+      'Updates a comment on an issue'
+    ),
+    schema: z.object(updateIssueCommentSchema(t)),
+    outputSchema: IssueCommentSchema,
+    importantFields: ['id', 'content', 'createdUser', 'updated'],
+    handler: async ({ issueId, issueKey, commentId, content }) => {
+      const result = resolveIdOrKey('issue', { id: issueId, key: issueKey }, t);
+      if (!result.ok) {
+        throw result.error;
+      }
+      return backlog.patchIssueComment(result.value, commentId, { content });
+    },
+  };
+};

--- a/src/tools/updateIssueComment.ts
+++ b/src/tools/updateIssueComment.ts
@@ -40,7 +40,7 @@ export const updateIssueCommentTool = (
   (typeof IssueCommentSchema)['shape']
 > => {
   return {
-    name: 'update_comment',
+    name: 'update_issue_comment',
     description: t(
       'TOOL_UPDATE_ISSUE_COMMENT_DESCRIPTION',
       'Updates a comment on an issue'


### PR DESCRIPTION
Closes #138

## Summary

Adds an `update_comment` tool for editing an existing issue comment, calling `PATCH /api/v2/issues/:issueIdOrKey/comments/:commentId` via `backlog-js`'s `patchIssueComment`.

- New `update_comment` tool: accepts `issueId`/`issueKey` (one required), `commentId`, and `content`
- Registered in the `issue` toolset in `src/tools/tools.ts`
- Unit tests added in `src/tools/updateIssueComment.test.ts`
- README updated with the new tool entry

## Test plan

- [x] Unit tests pass (`pnpm test` — 405 tests, all green)
- [x] Typecheck and lint pass
- [x] Verified live against a real Backlog space: posted a comment with `add_issue_comment`, edited it with `update_comment`, confirmed the content changed and `updated` timestamp advanced while `created` and comment `id` stayed the same
- [x] Verified both `issueKey` and numeric `issueId` identifier paths work
- [x] Verified formatted Markdown comments (headers, tables, checkboxes, code blocks, blockquotes, links) survive an add → edit round-trip unmodified, matching the existing `add_issue_comment` behavior