### PR TITLE
fix: fall back to issue key for non-positive IDs

### DIFF
--- a/src/tools/getIssue.test.ts
+++ b/src/tools/getIssue.test.ts
@@ -97,6 +97,15 @@ describe('getIssueTool', () => {
     expect(mockBacklog.getIssue).toHaveBeenCalledWith(1); // Expect number
   });
 
+  it('falls back to issue key when issue ID is not positive', async () => {
+    await tool.handler({
+      issueId: 0,
+      issueKey: 'TEST-1',
+    });
+
+    expect(mockBacklog.getIssue).toHaveBeenLastCalledWith('TEST-1');
+  });
+
   it('throws an error if neither issueId nor issueKey is provided', async () => {
     await expect(tool.handler({})).rejects.toThrow(Error);
   });

--- a/src/utils/resolveIdOrKey.ts
+++ b/src/utils/resolveIdOrKey.ts
@@ -45,7 +45,9 @@ function tryResolveIdOrField<F extends string>(
   fieldName: F,
   values: ResolveIdOrFieldInput<F>
 ): string | number | undefined {
-  return values.id !== undefined ? values.id : values[fieldName];
+  return values.id !== undefined && values.id > 0
+    ? values.id
+    : values[fieldName];
 }
 
 export const resolveIdOrKey = <E extends EntityName>(


### PR DESCRIPTION
## Problem

`get_issue` may receive both `issueId: 0` and a valid `issueKey` from MCP/LLM clients. The shared ID/key resolver treated any defined numeric ID as authoritative, so the valid issue key was ignored and `backlog.getIssue(0)` returned a 404.

## Fix

- Treat non-positive IDs as absent in the shared ID/key resolver.
- Fall back to the provided key when available.
- Add regression coverage for `issueId: 0` with a valid `issueKey`.

Closes #95

## Test plan

- [x] `pnpm test` (84 test files, 406 tests)
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:all`
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `git diff --check`