### PR TITLE
ci: make release workflow steps idempotent and retry release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,14 @@ jobs:
             --push .
 
       - name: Publish to npm
-        run: pnpm publish --no-git-checks --provenance --access public
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+        run: |
+          if npm view "backlog-mcp-server@${NEW_VERSION}" version > /dev/null 2>&1; then
+            echo "backlog-mcp-server@${NEW_VERSION} is already published, skipping."
+            exit 0
+          fi
+          pnpm publish --no-git-checks --provenance --access public
 
       - name: Push version update
         env:
@@ -96,6 +103,10 @@ jobs:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           git add package.json
+          if git diff --cached --quiet; then
+            echo "package.json is already at ${NEW_TAG}, skipping commit."
+            exit 0
+          fi
           git commit -m "chore(bump): ${NEW_TAG}"
           git push origin "HEAD:${DEFAULT_BRANCH}"
 
@@ -103,6 +114,10 @@ jobs:
         env:
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
         run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${NEW_TAG}" > /dev/null 2>&1; then
+            echo "Tag ${NEW_TAG} already exists, skipping."
+            exit 0
+          fi
           git tag "${NEW_TAG}"
           git push origin "${NEW_TAG}"
 
@@ -110,4 +125,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_TAG: ${{ steps.bump.outputs.new_tag }}
-        run: gh release create "${NEW_TAG}" --generate-notes
+        run: |
+          if gh release view "${NEW_TAG}" > /dev/null 2>&1; then
+            echo "Release ${NEW_TAG} already exists, skipping."
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            if gh release create "${NEW_TAG}" --generate-notes; then
+              exit 0
+            fi
+            echo "gh release create failed (attempt ${attempt}/3), retrying in 15s..."
+            sleep 15
+          done
+          echo "Failed to create release ${NEW_TAG} after 3 attempts." >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,9 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
         run: |
-          if npm view "backlog-mcp-server@${NEW_VERSION}" version > /dev/null 2>&1; then
-            echo "backlog-mcp-server@${NEW_VERSION} is already published, skipping."
+          package_name=$(node -p "require('./package.json').name")
+          if npm view "${package_name}@${NEW_VERSION}" version > /dev/null 2>&1; then
+            echo "${package_name}@${NEW_VERSION} is already published, skipping."
             exit 0
           fi
           pnpm publish --no-git-checks --provenance --access public


### PR DESCRIPTION
## 背景

[Run 30233736498](https://github.com/nulab/backlog-mcp-server/actions/runs/30233736498) が失敗し、v0.13.4 の GitHub Release が作られないままになっていました。

- **attempt 1**: npm publish・version commit・tag push まで全て成功し、最後の `gh release create` だけが GitHub API の一時的な **502 Bad Gateway** で失敗
- **attempt 2 (re-run)**: 再実行は dispatch 時の SHA（bump 前）を checkout するため、同じ `0.13.4` を再計算 → `npm error You cannot publish over the previously published versions: 0.13.4` で失敗

つまり「一時エラーで落ちた release を再実行して復旧する」ことが今のワークフローでは構造的にできませんでした。

## 変更内容

各公開ステップを冪等にして、再実行時は未完了の作業だけを埋めるようにします。

- **Publish to npm**: 対象バージョンが既に npm にある場合はスキップ
- **Push version update**: package.json に差分がない場合はコミットをスキップ
- **Push version tag**: タグが既に origin にある場合はスキップ
- **Create GitHub release**: 既存 release があればスキップ。加えて一時的な API エラーを吸収するため最大 3 回リトライ

## 補足

欠けていた v0.13.4 の GitHub Release は手動で作成済みです: https://github.com/nulab/backlog-mcp-server/releases/tag/v0.13.4
（npm / ghcr / tag / bump commit は attempt 1 で公開済みのため、追加対応は不要です）

🤖 Generated with [Claude Code](https://claude.com/claude-code)