### PR TITLE
feat: add related issues tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ Tools for managing issues, their comments, and related items like priorities, ca
 - `get_issue_comments`: Returns list of comments for an issue.
 - `add_issue_comment`: Adds a comment to an issue.
 - `update_issue_comment`: Updates a comment on an issue.
+- `get_related_issues`: Returns list of issues related to a specific issue.
+- `add_related_issue`: Relates an issue to another issue.
+- `remove_related_issue`: Removes the relation between an issue and a related issue.
 - `get_priorities`: Returns list of priorities.
 - `get_categories`: Returns list of categories for a project.
 - `get_custom_fields`: Returns list of custom fields for a project.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@hono/node-server": "^2.0.10",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "backlog-js": "^0.18.1",
+    "backlog-js": "^0.19.0",
     "cosmiconfig": "^9.0.1",
     "env-var": "^7.5.0",
     "graphql": "^16.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
       backlog-js:
-        specifier: ^0.18.1
-        version: 0.18.1
+        specifier: ^0.19.0
+        version: 0.19.0
       cosmiconfig:
         specifier: ^9.0.1
         version: 9.0.1(typescript@6.0.3)
@@ -834,8 +834,8 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
-  backlog-js@0.18.1:
-    resolution: {integrity: sha512-bTW2+dpJ3GpUW5UBIVV3zHbmOCP+Hrok2o/0sB6UFY6kgWtzzjFg3XiXjxRiI86gKOj87t+PhePcb76eBzcclA==}
+  backlog-js@0.19.0:
+    resolution: {integrity: sha512-X4C2uQRJD5Xt8gf0Ygje6C5LKjr43eCt40yiVYO8G4WmAITSJGpnDREA0f4jMar0Z66Kcf+Bt6ljTYDWw1l0kA==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -2378,7 +2378,7 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  backlog-js@0.18.1:
+  backlog-js@0.19.0:
     dependencies:
       qs: 6.15.2
 

--- a/src/tools/addRelatedIssue.test.ts
+++ b/src/tools/addRelatedIssue.test.ts
@@ -1,0 +1,56 @@
+import { addRelatedIssueTool } from './addRelatedIssue.js';
+import { vi, describe, it, expect } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+
+describe('addRelatedIssueTool', () => {
+  const mockBacklog: Partial<Backlog> = {
+    addRelatedIssue: vi.fn<() => Promise<any>>().mockResolvedValue({
+      id: 2,
+      projectId: 100,
+      issueKey: 'TEST-2',
+      keyId: 2,
+      summary: 'Related Issue',
+      type: 'RELATES',
+    }),
+  };
+
+  const mockTranslationHelper = createTranslationHelper();
+  const tool = addRelatedIssueTool(
+    mockBacklog as Backlog,
+    mockTranslationHelper
+  );
+
+  it('returns the related issue with its relation type', async () => {
+    const result = await tool.handler({
+      issueKey: 'TEST-1',
+      targetIssueId: 2,
+    });
+
+    if (Array.isArray(result)) {
+      throw new Error('Unexpected array result');
+    }
+    expect(result.issueKey).toEqual('TEST-2');
+    expect(result.type).toEqual('RELATES');
+  });
+
+  it('calls backlog.addRelatedIssue with the issue key and target issue ID', async () => {
+    await tool.handler({ issueKey: 'TEST-1', targetIssueId: 2 });
+
+    expect(mockBacklog.addRelatedIssue).toHaveBeenCalledWith('TEST-1', {
+      targetIssueId: 2,
+    });
+  });
+
+  it('calls backlog.addRelatedIssue with the issue ID', async () => {
+    await tool.handler({ issueId: 1, targetIssueId: 2 });
+
+    expect(mockBacklog.addRelatedIssue).toHaveBeenCalledWith(1, {
+      targetIssueId: 2,
+    });
+  });
+
+  it('throws an error if neither issueId nor issueKey is provided', async () => {
+    await expect(tool.handler({ targetIssueId: 2 })).rejects.toThrow(Error);
+  });
+});

--- a/src/tools/addRelatedIssue.ts
+++ b/src/tools/addRelatedIssue.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { Backlog } from 'backlog-js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+import { TranslationHelper } from '../createTranslationHelper.js';
+import { RelatedIssueSchema } from '../types/zod/backlogOutputDefinition.js';
+import { resolveIdOrKey } from '../utils/resolveIdOrKey.js';
+
+const addRelatedIssueSchema = buildToolSchema((t) => ({
+  issueId: z
+    .number()
+    .optional()
+    .describe(
+      t(
+        'TOOL_ADD_RELATED_ISSUE_ISSUE_ID',
+        'The numeric ID of the issue (e.g., 12345)'
+      )
+    ),
+  issueKey: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_ADD_RELATED_ISSUE_ISSUE_KEY',
+        "The key of the issue (e.g., 'PROJ-123')"
+      )
+    ),
+  targetIssueId: z
+    .number()
+    .describe(
+      t(
+        'TOOL_ADD_RELATED_ISSUE_TARGET_ISSUE_ID',
+        'The numeric ID of the issue to relate to (e.g., 12346)'
+      )
+    ),
+}));
+
+export const addRelatedIssueTool = (
+  backlog: Backlog,
+  { t }: TranslationHelper
+): ToolDefinition<
+  ReturnType<typeof addRelatedIssueSchema>,
+  (typeof RelatedIssueSchema)['shape']
+> => {
+  return {
+    name: 'add_related_issue',
+    description: t(
+      'TOOL_ADD_RELATED_ISSUE_DESCRIPTION',
+      'Relates an issue to another issue'
+    ),
+    schema: z.object(addRelatedIssueSchema(t)),
+    outputSchema: RelatedIssueSchema,
+    handler: async ({ issueId, issueKey, targetIssueId }) => {
+      const result = resolveIdOrKey('issue', { id: issueId, key: issueKey }, t);
+      if (!result.ok) {
+        throw result.error;
+      }
+      return backlog.addRelatedIssue(result.value, { targetIssueId });
+    },
+  };
+};

--- a/src/tools/getRelatedIssues.test.ts
+++ b/src/tools/getRelatedIssues.test.ts
@@ -1,0 +1,54 @@
+import { getRelatedIssuesTool } from './getRelatedIssues.js';
+import { vi, describe, it, expect } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+
+describe('getRelatedIssuesTool', () => {
+  const relatedIssue = {
+    id: 2,
+    projectId: 100,
+    issueKey: 'TEST-2',
+    keyId: 2,
+    summary: 'Related Issue',
+    type: 'RELATES',
+  };
+
+  const mockBacklog: Partial<Backlog> = {
+    getRelatedIssues: vi
+      .fn<() => Promise<any>>()
+      .mockResolvedValue([relatedIssue]),
+  };
+
+  const mockTranslationHelper = createTranslationHelper();
+  const tool = getRelatedIssuesTool(
+    mockBacklog as Backlog,
+    mockTranslationHelper
+  );
+
+  it('returns the related issues with their relation type', async () => {
+    const result = await tool.handler({ issueKey: 'TEST-1' });
+
+    if (!Array.isArray(result)) {
+      throw new Error('Expected an array result');
+    }
+    expect(result).toHaveLength(1);
+    expect(result[0].issueKey).toEqual('TEST-2');
+    expect(result[0].type).toEqual('RELATES');
+  });
+
+  it('calls backlog.getRelatedIssues with the issue key', async () => {
+    await tool.handler({ issueKey: 'TEST-1' });
+
+    expect(mockBacklog.getRelatedIssues).toHaveBeenCalledWith('TEST-1');
+  });
+
+  it('calls backlog.getRelatedIssues with the issue ID', async () => {
+    await tool.handler({ issueId: 1 });
+
+    expect(mockBacklog.getRelatedIssues).toHaveBeenCalledWith(1);
+  });
+
+  it('throws an error if neither issueId nor issueKey is provided', async () => {
+    await expect(tool.handler({})).rejects.toThrow(Error);
+  });
+});

--- a/src/tools/getRelatedIssues.ts
+++ b/src/tools/getRelatedIssues.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { Backlog } from 'backlog-js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+import { TranslationHelper } from '../createTranslationHelper.js';
+import { RelatedIssueSchema } from '../types/zod/backlogOutputDefinition.js';
+import { resolveIdOrKey } from '../utils/resolveIdOrKey.js';
+
+const getRelatedIssuesSchema = buildToolSchema((t) => ({
+  issueId: z
+    .number()
+    .optional()
+    .describe(
+      t(
+        'TOOL_GET_RELATED_ISSUES_ISSUE_ID',
+        'The numeric ID of the issue (e.g., 12345)'
+      )
+    ),
+  issueKey: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_GET_RELATED_ISSUES_ISSUE_KEY',
+        "The key of the issue (e.g., 'PROJ-123')"
+      )
+    ),
+}));
+
+export const getRelatedIssuesTool = (
+  backlog: Backlog,
+  { t }: TranslationHelper
+): ToolDefinition<
+  ReturnType<typeof getRelatedIssuesSchema>,
+  (typeof RelatedIssueSchema)['shape']
+> => {
+  return {
+    name: 'get_related_issues',
+    description: t(
+      'TOOL_GET_RELATED_ISSUES_DESCRIPTION',
+      'Returns list of issues related to a specific issue'
+    ),
+    schema: z.object(getRelatedIssuesSchema(t)),
+    importantFields: ['issueKey', 'summary', 'status', 'type'],
+    outputSchema: RelatedIssueSchema,
+    handler: async ({ issueId, issueKey }) => {
+      const result = resolveIdOrKey('issue', { id: issueId, key: issueKey }, t);
+      if (!result.ok) {
+        throw result.error;
+      }
+      return backlog.getRelatedIssues(result.value);
+    },
+  };
+};

--- a/src/tools/removeRelatedIssue.test.ts
+++ b/src/tools/removeRelatedIssue.test.ts
@@ -1,0 +1,51 @@
+import { removeRelatedIssueTool } from './removeRelatedIssue.js';
+import { vi, describe, it, expect } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createTranslationHelper } from '../createTranslationHelper.js';
+
+describe('removeRelatedIssueTool', () => {
+  const mockBacklog: Partial<Backlog> = {
+    removeRelatedIssue: vi.fn<() => Promise<any>>().mockResolvedValue({
+      id: 2,
+      projectId: 100,
+      issueKey: 'TEST-2',
+      keyId: 2,
+      summary: 'Related Issue',
+      type: 'RELATES',
+    }),
+  };
+
+  const mockTranslationHelper = createTranslationHelper();
+  const tool = removeRelatedIssueTool(
+    mockBacklog as Backlog,
+    mockTranslationHelper
+  );
+
+  it('returns the unlinked issue', async () => {
+    const result = await tool.handler({
+      issueKey: 'TEST-1',
+      relatedIssueId: 2,
+    });
+
+    if (Array.isArray(result)) {
+      throw new Error('Unexpected array result');
+    }
+    expect(result.issueKey).toEqual('TEST-2');
+  });
+
+  it('calls backlog.removeRelatedIssue with the issue key and related issue ID', async () => {
+    await tool.handler({ issueKey: 'TEST-1', relatedIssueId: 2 });
+
+    expect(mockBacklog.removeRelatedIssue).toHaveBeenCalledWith('TEST-1', 2);
+  });
+
+  it('calls backlog.removeRelatedIssue with the issue ID', async () => {
+    await tool.handler({ issueId: 1, relatedIssueId: 2 });
+
+    expect(mockBacklog.removeRelatedIssue).toHaveBeenCalledWith(1, 2);
+  });
+
+  it('throws an error if neither issueId nor issueKey is provided', async () => {
+    await expect(tool.handler({ relatedIssueId: 2 })).rejects.toThrow(Error);
+  });
+});

--- a/src/tools/removeRelatedIssue.ts
+++ b/src/tools/removeRelatedIssue.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+import { Backlog } from 'backlog-js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+import { TranslationHelper } from '../createTranslationHelper.js';
+import { RelatedIssueSchema } from '../types/zod/backlogOutputDefinition.js';
+import { resolveIdOrKey } from '../utils/resolveIdOrKey.js';
+
+const removeRelatedIssueSchema = buildToolSchema((t) => ({
+  issueId: z
+    .number()
+    .optional()
+    .describe(
+      t(
+        'TOOL_REMOVE_RELATED_ISSUE_ISSUE_ID',
+        'The numeric ID of the issue (e.g., 12345)'
+      )
+    ),
+  issueKey: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_REMOVE_RELATED_ISSUE_ISSUE_KEY',
+        "The key of the issue (e.g., 'PROJ-123')"
+      )
+    ),
+  relatedIssueId: z
+    .number()
+    .describe(
+      t(
+        'TOOL_REMOVE_RELATED_ISSUE_RELATED_ISSUE_ID',
+        'The numeric ID of the related issue to unlink (e.g., 12346)'
+      )
+    ),
+}));
+
+export const removeRelatedIssueTool = (
+  backlog: Backlog,
+  { t }: TranslationHelper
+): ToolDefinition<
+  ReturnType<typeof removeRelatedIssueSchema>,
+  (typeof RelatedIssueSchema)['shape']
+> => {
+  return {
+    name: 'remove_related_issue',
+    description: t(
+      'TOOL_REMOVE_RELATED_ISSUE_DESCRIPTION',
+      'Removes the relation between an issue and a related issue'
+    ),
+    schema: z.object(removeRelatedIssueSchema(t)),
+    outputSchema: RelatedIssueSchema,
+    handler: async ({ issueId, issueKey, relatedIssueId }) => {
+      const result = resolveIdOrKey('issue', { id: issueId, key: issueKey }, t);
+      if (!result.ok) {
+        throw result.error;
+      }
+      return backlog.removeRelatedIssue(result.value, relatedIssueId);
+    },
+  };
+};

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -18,6 +18,9 @@ import { getGitRepositoryTool } from './getGitRepository.js';
 import { getIssueTool } from './getIssue.js';
 import { getIssueCommentsTool } from './getIssueComments.js';
 import { getIssuesTool } from './getIssues.js';
+import { getRelatedIssuesTool } from './getRelatedIssues.js';
+import { addRelatedIssueTool } from './addRelatedIssue.js';
+import { removeRelatedIssueTool } from './removeRelatedIssue.js';
 import { getIssueTypesTool } from './getIssueTypes.js';
 import { getMyselfTool } from './getMyself.js';
 import { getNotificationsTool } from './getNotifications.js';
@@ -109,6 +112,9 @@ export const allTools = (
           getIssueCommentsTool(backlog, helper),
           addIssueCommentTool(backlog, helper),
           updateIssueCommentTool(backlog, helper),
+          getRelatedIssuesTool(backlog, helper),
+          addRelatedIssueTool(backlog, helper),
+          removeRelatedIssueTool(backlog, helper),
           getPrioritiesTool(backlog, helper),
           getCategoriesTool(backlog, helper),
           getCustomFieldsTool(backlog, helper),

--- a/src/types/zod/backlogOutputDefinition.ts
+++ b/src/types/zod/backlogOutputDefinition.ts
@@ -232,6 +232,11 @@ export const IssueSchema = z.object({
   stars: z.array(StarSchema),
 });
 
+// An issue plus the relation type that links it to the issue it was fetched from.
+export const RelatedIssueSchema = IssueSchema.extend({
+  type: z.string(),
+});
+
 export const ProjectSchema = z.object({
   id: z.number(),
   projectKey: z.string(),


### PR DESCRIPTION
## Summary

Adds tools for the related issues API to the `issue` toolset, backed by the client methods that shipped in [backlog-js v0.19.0](https://github.com/nulab/backlog-js/releases/tag/v0.19.0) (nulab/backlog-js#181).

| Tool | Endpoint |
| --- | --- |
| `get_related_issues` | `GET /api/v2/issues/:issueIdOrKey/relatedIssues` |
| `add_related_issue` | `POST /api/v2/issues/:issueIdOrKey/relatedIssues` |
| `remove_related_issue` | `DELETE /api/v2/issues/:issueIdOrKey/relatedIssues/:relatedIssueId` |

- Bumps `backlog-js` to `^0.19.0`.
- Adds `RelatedIssueSchema` — an issue plus the `type` field the API returns alongside it.
- All three tools accept `issueId` / `issueKey` through the existing `resolveIdOrKey` helper, consistent with the other issue tools.

## Scope

The API currently supports only a single, undirected relation type, so the tools intentionally expose **no relation-type argument** and `RelatedIssueSchema.type` is a plain string rather than an enum. This keeps the tool surface to what the API actually supports today, so nothing has to change here when the relation model is extended.

`add_related_issue` takes a numeric `targetIssueId` because that is what the endpoint accepts. Resolving a target issue *key* to an ID would need an extra `getIssue` call, so it is left out for now and can be added if it turns out agents need it.

## Verification

- Unit tests for all three tools (12 cases): return value shape, `issueKey` / `issueId` pass-through, and the error when neither is given.
- Full suite: 419 tests pass. `typecheck`, `typecheck:all`, `lint` and `format` are clean.
- The tool handlers were also run against a real Backlog space, confirming the tools return the related issue with `type: "RELATES"` and that `remove_related_issue` / `add_related_issue` round-trip correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)