### PR TITLE
chore(npmrc): exclude backlog-js from minimum-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
 minimum-release-age=4320
+# backlog-js is maintained in-house (nulab/backlog-js), so the delay that
+# guards against compromised third-party releases only slows us down here.
+minimum-release-age-exclude[]=backlog-js


### PR DESCRIPTION
## Summary

`minimum-release-age=4320` (3 days) makes pnpm refuse any release published in the last three days. That is the right default for third-party dependencies — it is what #179 added it for — but `backlog-js` is our own package, so the delay only blocks us from picking up our own API client right after we publish it.

This adds `backlog-js` to `minimumReleaseAgeExclude`, keeping the 3-day delay for everything else.

```
minimum-release-age=4320
minimum-release-age-exclude[]=backlog-js
```

## Why this came up

Bumping `backlog-js` to `0.19.0` right after its release failed with:

```
The latest release of backlog-js is "0.19.0". Published at ...
If you want to install the matched version ignoring the time it was published,
you can add the package name to the minimumReleaseAgeExclude setting.
```

## Verification

On this branch (`backlog-js@^0.18.1` in `package.json`), changing the range to `^0.19.0` and running `pnpm install --lockfile-only` now resolves the just-published version without the age error; reverting the `.npmrc` line brings the error back. `pnpm install --frozen-lockfile` is unaffected.

Verified with the pinned `pnpm@10.34.4`. The setting is also accepted in `pnpm-workspace.yaml` form, but `.npmrc` is where this repo already keeps it. See [pnpm docs](https://pnpm.io/settings#minimumreleaseageexclude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)