### PR TITLE
Migrate zod v3 to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@hono/node-server": "^2.0.10",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "backlog-js": "^0.19.0",
+    "backlog-js": "^0.19.1",
     "cosmiconfig": "^9.0.1",
     "env-var": "^7.5.0",
     "graphql": "^16.14.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "yargs": "^18.0.0",
-    "zod": "^3.24.3"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.0.11(hono@4.12.27)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       backlog-js:
         specifier: ^0.19.0
         version: 0.19.0
@@ -39,8 +39,8 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
       zod:
-        specifier: ^3.24.3
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -1812,8 +1812,8 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -2061,7 +2061,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
       ajv: 8.20.0
@@ -2078,8 +2078,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3355,8 +3355,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
       backlog-js:
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^0.19.1
+        version: 0.19.1
       cosmiconfig:
         specifier: ^9.0.1
         version: 9.0.1(typescript@6.0.3)
@@ -834,8 +834,8 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
-  backlog-js@0.19.0:
-    resolution: {integrity: sha512-X4C2uQRJD5Xt8gf0Ygje6C5LKjr43eCt40yiVYO8G4WmAITSJGpnDREA0f4jMar0Z66Kcf+Bt6ljTYDWw1l0kA==}
+  backlog-js@0.19.1:
+    resolution: {integrity: sha512-MPmQw9U0u4t4pHPSd+Pc9EK2gboO7Gq0N/PGAeehfZjyfaWFa/pUip+8xHtHWuCft4Bn1QAG4ForIdXmAlJElg==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -2378,7 +2378,7 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  backlog-js@0.19.0:
+  backlog-js@0.19.1:
     dependencies:
       qs: 6.15.2
 

--- a/src/handlers/builders/composeToolHandler.ts
+++ b/src/handlers/builders/composeToolHandler.ts
@@ -58,7 +58,7 @@ function extendSchema<I extends z.ZodRawShape>(
     fields?: z.ZodString;
   }
 > {
-  const extension: Record<string, z.ZodTypeAny> = {
+  const extension: Record<string, z.ZodType> = {
     organization: z
       .string()
       .optional()
@@ -71,7 +71,10 @@ function extendSchema<I extends z.ZodRawShape>(
     extension.fields = z.string().describe(desc);
   }
 
-  return schema.extend(extension) as z.ZodObject<
+  // zod v4 reworked the ZodObject shape generics, so `extend()`'s result no
+  // longer overlaps the declared return type enough for a direct cast. The
+  // shape is correct at runtime; route through `unknown` to keep the assertion.
+  return schema.extend(extension) as unknown as z.ZodObject<
     I & {
       organization: z.ZodOptional<z.ZodString>;
       fields?: z.ZodString;

--- a/src/tools/getDocumentTree.ts
+++ b/src/tools/getDocumentTree.ts
@@ -32,7 +32,12 @@ export const getDocumentTreeTool = (
     outputSchema: DocumentTreeFullSchemaZ,
     importantFields: ['projectId', 'activeTree', 'trashTree'],
     handler: async ({ projectIdOrKey }) => {
-      return backlog.getDocumentTree(projectIdOrKey);
+      // backlog-js declares DocumentTree.projectId as `string`, but the API
+      // returns a number (verified against a live space: `"projectId": 1073957945`).
+      // The schema above is the correct one, so cast over the upstream mistype.
+      return (await backlog.getDocumentTree(
+        projectIdOrKey
+      )) as unknown as z.infer<typeof DocumentTreeFullSchemaZ>;
     },
   };
 };

--- a/src/tools/getDocumentTree.ts
+++ b/src/tools/getDocumentTree.ts
@@ -32,12 +32,7 @@ export const getDocumentTreeTool = (
     outputSchema: DocumentTreeFullSchemaZ,
     importantFields: ['projectId', 'activeTree', 'trashTree'],
     handler: async ({ projectIdOrKey }) => {
-      // backlog-js declares DocumentTree.projectId as `string`, but the API
-      // returns a number (verified against a live space: `"projectId": 1073957945`).
-      // The schema above is the correct one, so cast over the upstream mistype.
-      return (await backlog.getDocumentTree(
-        projectIdOrKey
-      )) as unknown as z.infer<typeof DocumentTreeFullSchemaZ>;
+      return backlog.getDocumentTree(projectIdOrKey);
     },
   };
 };

--- a/src/types/zod/backlogOutputDefinition.ts
+++ b/src/types/zod/backlogOutputDefinition.ts
@@ -556,7 +556,10 @@ export const ActiveTrashTreeSchema = z.object({
   children: z.array(DocumentTreeNodeSchema),
 });
 
-export const DocumentTreeFullSchema: z.ZodRawShape = {
+// No `: z.ZodRawShape` annotation here: it erases the concrete shape, so
+// `z.infer<typeof DocumentTreeFullSchemaZ>` collapses to Record<string, unknown>
+// and backlog-js's DocumentTree (no index signature) stops being assignable.
+export const DocumentTreeFullSchema = {
   projectId: z.number(),
   activeTree: ActiveTrashTreeSchema.optional(),
   trashTree: ActiveTrashTreeSchema.optional(),

--- a/src/utils/generateFieldsDescription.ts
+++ b/src/utils/generateFieldsDescription.ts
@@ -1,4 +1,4 @@
-import { z, ZodRawShape, ZodTypeAny } from 'zod';
+import { z, ZodRawShape, ZodType } from 'zod';
 
 /**
  * Generate GraphQL like fields and type specs from Zod types
@@ -34,7 +34,7 @@ function generateGraphQLType(
 ): string {
   const lines: string[] = [`type ${typeName} {`];
   for (const [key, value] of Object.entries(schema.shape)) {
-    lines.push(`  ${key}: ${mapZodTypeToGraphQLType(value as ZodTypeAny)}`);
+    lines.push(`  ${key}: ${mapZodTypeToGraphQLType(value as ZodType)}`);
   }
   lines.push('}');
   return lines.join('\n');
@@ -43,14 +43,23 @@ function generateGraphQLType(
 /**
  * Zod to graphql
  */
-function mapZodTypeToGraphQLType(zodType: z.ZodTypeAny): string {
+function mapZodTypeToGraphQLType(zodType: z.ZodType): string {
   if (zodType instanceof z.ZodString) return 'String!';
   if (zodType instanceof z.ZodNumber) return 'Int!';
   if (zodType instanceof z.ZodBoolean) return 'Boolean!';
+  // zod v4 types `.unwrap()` as the core `$ZodType` rather than the classic
+  // `ZodType`, so the recursive call needs a cast. The runtime value is a
+  // classic schema either way - only the declared type narrowed.
   if (zodType instanceof z.ZodNullable)
-    return mapZodTypeToGraphQLType(zodType.unwrap()).replace(/!$/, '');
+    return mapZodTypeToGraphQLType(zodType.unwrap() as z.ZodType).replace(
+      /!$/,
+      ''
+    );
   if (zodType instanceof z.ZodOptional)
-    return mapZodTypeToGraphQLType(zodType.unwrap()).replace(/!$/, '');
+    return mapZodTypeToGraphQLType(zodType.unwrap() as z.ZodType).replace(
+      /!$/,
+      ''
+    );
 
   // Spec: a nested part is JSON
   if (zodType instanceof z.ZodObject) return 'JSON';


### PR DESCRIPTION
Closes #171. Prerequisite for #170.

## 概要

zod を v3 (`^3.24.3`) から v4 (`^4.4.3`) へ移行します。

MCP SDK v2 はツールスキーマを Standard Schema に移し、`@modelcontextprotocol/server@2.0.0` が `zod: ^4.2.0` を直接依存として宣言しているため、zod v3 のままでは #170 の SDK 移行に着手できません。

## 結果として差分は小さくなりました

73ファイルが zod を import していますが、**変更は6ファイルのみ**です。v3→v4 の定番の破壊的変更（`z.string().email()`、単一引数の `z.record()`、`.strict()`、`errorMap`、`.deepPartial()` など）がこのリポジトリに1件も使われていなかったためです。

**全ステップで 422 tests が変更なしにパスし続けました。** zod を上げただけの状態で型エラーは4件だけでした。

## 変更内容

### 1. `generateFieldsDescription.ts`

v4 は `.unwrap()` の戻り値を classic な `ZodType` ではなく core の `$ZodType` として型付けするため、再帰呼び出しにキャストが必要になりました。ランタイムの値は変わりません。

### 2. `composeToolHandler.ts`

v4 で `ZodObject` のシェイプ generics が刷新され、`extend()` の結果が宣言された戻り値型と十分に重ならなくなり直接のアサーションが拒否されるため、`unknown` を経由させています。

### 3. `getDocumentTree.ts` — 隠れていたバグが露出しました

`DocumentTreeFullSchema` の `: z.ZodRawShape` 注釈を外したところ、**この注釈が隠していた既存のバグ**が出てきました。注釈が具体的な形を消して `z.infer` を `Record<string, unknown>` に潰していたため、何でも代入可能になっていたのです。

本来の形が復元されると、backlog-js の `DocumentTree` が型検査を通らなくなりました。`projectId` を `string` と宣言しているためです。

**実際の Backlog スペースに対して確認したところ、API は `"projectId": 1073957945` という数値を返します。** つまりこちらのスキーマ (`z.number()`) が正しく、backlog-js の型定義が誤っていました。

これは **backlog-js 側で修正済みです**（[nulab/backlog-js#184](https://github.com/nulab/backlog-js/pull/184)、0.19.1 でリリース）。当初はこちらで `as unknown as` キャストして回避していましたが、上流が直ったので **`backlog-js` を `^0.19.1` に上げてキャストを削除**しました。ハンドラは元の1行のままです。回避策がこの PR 内で導入され同じ PR 内で消えるため、main には一度も入りません。

## codemod について

`zod-v3-to-v4` codemod を実行しましたが、**大半を取り消しています。**

- ✅ **採用**: `ZodTypeAny` → `ZodType` のリネーム（v4 で `ZodTypeAny` は削除済み）
- ❌ **不採用**: `z.nativeEnum` → `z.enum` の変換

後者を戻した理由は**型安全性の後退**です。数値の enum 風オブジェクトに対して `z.enum` は推論型をリテラル union から素の `number` へ広げてしまい、新規の型エラーが2件発生しました。

```ts
z.nativeEnum({ A: -1, B: 1, C: 2 })  // -> -1 | 1 | 2
z.enum({ A: -1, B: 1, C: 2 })        // -> number   ← 広がる
```

`as const` を付けるとリテラルは復元されますが、それでも型検査は通りませんでした（4件 → 6件のまま）。`nativeEnum` は v4 でも非推奨ながら動作するため、4箇所はそのまま残しています。非推奨の解消のために型安全性を犠牲にするのは割に合いません。#171 に残課題として記録済みです。

## `.default()` の監査

v4 では `.default()` の値が出力型として扱われ、スキーマを通らなくなります（旧挙動は `.prefault()`）。コンパイルエラーにならず静かに壊れる変更なので、15箇所すべてを確認しました。

- **11箇所は `env-var` ライブラリのもので zod ではありません**（`src/index.ts`）
- **残る4箇所は素の `number` / `string` / `enum` スキーマ**で transform も coercion も伴わないため、この変更は no-op です

4箇所すべてについて、実行時に期待通りのデフォルト値を返すことを確認しました。

## Test plan

- [x] `pnpm test` — 87 files / **422 tests passing**（ベースラインから変化なし）
- [x] `tsc --noEmit` — **0 errors**
- [x] `pnpm lint` (eslint) — 0 errors
- [x] `prettier --check` — pass
- [x] `.default()` 4箇所のランタイム挙動を検証
- [x] `z.nativeEnum` と `z.enum` の推論型の差を型レベルで検証
- [x] `getDocumentTree` の `projectId` を実 API のレスポンスで確認
- [x] `backlog-js` 0.19.1 でキャストなしに `tsc --noEmit` が通ることを確認
- [x] `pnpm build` — success

### 補足

`.npmrc` の `minimum-release-age=4320`（72時間）は zod 4.4.3 に対しては問題ありません（2026-05-04 公開、経過2000時間超）。

backlog-js の `DocumentTree.projectId` の型誤りは [nulab/backlog-js#183](https://github.com/nulab/backlog-js/issues/183) として報告し、[#184](https://github.com/nulab/backlog-js/pull/184) で修正・0.19.1 としてリリース済みです。`.npmrc` の `minimum-release-age-exclude[]=backlog-js` により72時間待ちの対象外なので、公開直後から利用できました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
