### PR TITLE
fix: stop mutating shared tool definitions, and measure per-request construction (#174)

### DIFF
--- a/src/dynamicToolsetPersistence.test.ts
+++ b/src/dynamicToolsetPersistence.test.ts
@@ -93,24 +93,27 @@ describe('dynamic toolset enablement across servers from one factory', () => {
     );
   });
 
-  // `composeToolHandler` extends `tool.schema` in place. That mutation used to
-  // land on throwaway per-server definitions; sharing the group makes it
-  // cross-request, so its convergence is now load-bearing rather than
-  // incidental — a re-extension that accumulated keys would corrupt the tool
-  // schema every client sees after the first request.
-  it('keeps tool input schemas stable across repeated registration', () => {
+  // Registration composes `organization` (and `fields`) onto a copy of the
+  // tool's schema. The shared group is read by every per-request server, so
+  // registration must leave the definitions exactly as `buildToolsetGroup` left
+  // them — a definition that grew keys per request would corrupt the schema
+  // every client sees after the first one.
+  it('does not mutate shared tool definitions when registering', () => {
     const transHelper = createTranslationHelper();
     const sharedToolsetGroup = buildToolsetGroup(backlog, transHelper, ['all']);
 
-    const shapeOfFirstTool = () => {
-      const tool = sharedToolsetGroup.toolsets[0].tools[0];
-      return Object.keys((tool.schema as { shape: object }).shape).sort();
-    };
+    const firstTool = () => sharedToolsetGroup.toolsets[0].tools[0];
+    const shapeOfFirstTool = () =>
+      Object.keys((firstTool().schema as { shape: object }).shape).sort();
+
+    const pristineSchema = firstTool().schema;
+    const pristineShape = shapeOfFirstTool();
+    expect(pristineShape).not.toContain('organization');
 
     const register = () =>
       createBacklogMcpServer({
         version: '1.0.0',
-        useFields: true, // adds `fields` on top of `organization`
+        useFields: true, // would add `fields` on top of `organization`
         backlog,
         clientRegistry,
         transHelper,
@@ -121,13 +124,10 @@ describe('dynamic toolset enablement across servers from one factory', () => {
       });
 
     register();
-    const afterFirst = shapeOfFirstTool();
-    expect(afterFirst).toEqual(
-      expect.arrayContaining(['organization', 'fields'])
-    );
+    register();
+    register();
 
-    register();
-    register();
-    expect(shapeOfFirstTool()).toEqual(afterFirst);
+    expect(firstTool().schema).toBe(pristineSchema);
+    expect(shapeOfFirstTool()).toEqual(pristineShape);
   });
 });

--- a/src/handlers/builders/composeToolHandler.test.ts
+++ b/src/handlers/builders/composeToolHandler.test.ts
@@ -32,12 +32,12 @@ describe('composeToolHandler', () => {
   };
 
   it("adds 'fields' when useFields is true", async () => {
-    const composed = composeToolHandler(tool, {
+    const { schema, handler: composed } = composeToolHandler(tool, {
       useFields: true,
       maxTokens: 500,
     });
 
-    expect(tool.schema.shape).toHaveProperty('fields');
+    expect(schema.shape).toHaveProperty('fields');
 
     const result = await composed({ id: 123, fields: '{ id }' }, dummyExtra);
     const content = (result as CallToolResult).content[0];
@@ -58,12 +58,15 @@ describe('composeToolHandler', () => {
       })),
     };
 
-    const composed = composeToolHandler(toolWithoutFields, {
-      useFields: false,
-      maxTokens: 500,
-    });
+    const { schema, handler: composed } = composeToolHandler(
+      toolWithoutFields,
+      {
+        useFields: false,
+        maxTokens: 500,
+      }
+    );
 
-    expect(toolWithoutFields.schema.shape).not.toHaveProperty('fields');
+    expect(schema.shape).not.toHaveProperty('fields');
 
     const result = await composed({ id: 456 }, dummyExtra);
     const content = (result as CallToolResult).content[0];
@@ -75,7 +78,7 @@ describe('composeToolHandler', () => {
   });
 
   it('extends schema and composes handler with field picking and token limit', async () => {
-    const composed = composeToolHandler(tool, {
+    const { handler: composed } = composeToolHandler(tool, {
       useFields: true,
       errorHandler: dummyErrorHandler,
       maxTokens: 100,
@@ -92,7 +95,7 @@ describe('composeToolHandler', () => {
     }
   });
 
-  it("adds 'organization' when useOrganization is true", async () => {
+  it("adds 'organization' to the returned schema when useOrganization is true", async () => {
     const orgTool: ToolDefinition<any, any> = {
       ...tool,
       schema: z.object({
@@ -100,13 +103,30 @@ describe('composeToolHandler', () => {
       }),
     };
 
-    composeToolHandler(orgTool, {
+    const { schema } = composeToolHandler(orgTool, {
       useFields: true,
       maxTokens: 100,
       useOrganization: true,
     });
 
-    expect(orgTool.schema.shape).toHaveProperty('organization');
+    expect(schema.shape).toHaveProperty('organization');
+  });
+
+  // One toolset group is shared by every per-request server on the HTTP
+  // transport, so composing must not touch the definition: a mutation would be
+  // re-applied on every request and seen by requests composing concurrently.
+  it('leaves the tool definition untouched', () => {
+    const pristine: ToolDefinition<any, any> = {
+      ...tool,
+      schema: z.object({ name: z.string() }),
+    };
+    const before = pristine.schema;
+
+    composeToolHandler(pristine, { useFields: true, maxTokens: 100 });
+    composeToolHandler(pristine, { useFields: true, maxTokens: 100 });
+
+    expect(pristine.schema).toBe(before);
+    expect(Object.keys(pristine.schema.shape)).toEqual(['name']);
   });
 
   // With a single Backlog space the parameter has exactly one legal value, so
@@ -117,14 +137,14 @@ describe('composeToolHandler', () => {
       schema: z.object({ name: z.string() }),
     };
 
-    composeToolHandler(soloTool, {
+    const { schema } = composeToolHandler(soloTool, {
       useFields: true,
       maxTokens: 100,
       useOrganization: false,
     });
 
-    expect(soloTool.schema.shape).not.toHaveProperty('organization');
-    expect(soloTool.schema.shape).toHaveProperty('fields');
+    expect(schema.shape).not.toHaveProperty('organization');
+    expect(schema.shape).toHaveProperty('fields');
   });
 
   // Not advertising the parameter must not turn it into a hazard. The
@@ -139,7 +159,7 @@ describe('composeToolHandler', () => {
       handler: async () => ({ id: 1, name: 'Sample' }),
     };
 
-    const composed = composeToolHandler(orgTool, {
+    const { handler: composed } = composeToolHandler(orgTool, {
       useFields: false,
       maxTokens: 100,
       useOrganization: false,
@@ -157,7 +177,7 @@ describe('composeToolHandler', () => {
       },
     };
 
-    const composed = composeToolHandler(errorTool, {
+    const { handler: composed } = composeToolHandler(errorTool, {
       useFields: true,
       errorHandler: dummyErrorHandler,
       maxTokens: 100,

--- a/src/handlers/builders/composeToolHandler.test.ts
+++ b/src/handlers/builders/composeToolHandler.test.ts
@@ -147,6 +147,29 @@ describe('composeToolHandler', () => {
     expect(schema.shape).toHaveProperty('fields');
   });
 
+  // The consequence of the mutation this replaced: once a `useFields: true`
+  // compose had baked `fields` into the definition, every later compose kept
+  // advertising it — including `useFields: false` ones, which do not apply
+  // field picking, so clients saw a parameter that was silently ignored.
+  it('honours useFields per call on a reused definition', () => {
+    const reused: ToolDefinition<any, any> = {
+      ...tool,
+      schema: z.object({ name: z.string() }),
+    };
+
+    const withFields = composeToolHandler(reused, {
+      useFields: true,
+      maxTokens: 100,
+    });
+    expect(withFields.schema.shape).toHaveProperty('fields');
+
+    const withoutFields = composeToolHandler(reused, {
+      useFields: false,
+      maxTokens: 100,
+    });
+    expect(withoutFields.schema.shape).not.toHaveProperty('fields');
+  });
+
   // Not advertising the parameter must not turn it into a hazard. The
   // organization wrapper stays in the chain whatever `useOrganization` says, so
   // a handler that still receives the field is served rather than erroring.

--- a/src/handlers/builders/composeToolHandler.ts
+++ b/src/handlers/builders/composeToolHandler.ts
@@ -28,6 +28,14 @@ type ComposedInput = {
 
 type ComposedHandler = (input: ComposedInput) => Promise<SafeResult<unknown>>;
 
+/**
+ * Builds the schema and handler a tool is registered with.
+ *
+ * The returned schema is a fresh object: the tool definition is never mutated.
+ * That matters under the stateless HTTP model, where one toolset group is shared
+ * by every per-request server — an in-place extension would be re-applied on
+ * every request, against a definition other requests are reading concurrently.
+ */
 export function composeToolHandler(
   tool: ToolDefinition<any, any>,
   options: ComposeOptions
@@ -47,7 +55,7 @@ export function composeToolHandler(
         tool.name
       )
     : undefined;
-  tool.schema = extendSchema(tool.schema, fieldDesc, useOrganization);
+  const schema = extendSchema(tool.schema, fieldDesc, useOrganization);
 
   // Step 2: Compose
   const baseHandler: ComposedHandler = wrapWithErrorHandling(
@@ -55,9 +63,12 @@ export function composeToolHandler(
     errorHandler
   );
 
-  const handler = useFields ? wrapWithFieldPicking(baseHandler) : baseHandler;
+  const composed = useFields ? wrapWithFieldPicking(baseHandler) : baseHandler;
 
-  return wrapWithToolResult(wrapWithTokenLimit(handler, maxTokens));
+  return {
+    schema,
+    handler: wrapWithToolResult(wrapWithTokenLimit(composed, maxTokens)),
+  };
 }
 
 function extendSchema<I extends z.ZodRawShape>(

--- a/src/registerTools.test.ts
+++ b/src/registerTools.test.ts
@@ -8,7 +8,12 @@ import { buildToolsetGroup } from './utils/toolsetUtils.js';
 import { wrapServerWithToolRegistry } from './utils/wrapServerWithToolRegistry.js';
 import type { Toolset } from './types/toolsets.js';
 
-vi.mock('./handlers/builders/composeToolHandler');
+vi.mock('./handlers/builders/composeToolHandler', () => ({
+  composeToolHandler: vi.fn((tool) => ({
+    schema: tool.schema,
+    handler: vi.fn(),
+  })),
+}));
 
 describe('registerTools', () => {
   const mockBacklog = {} as Backlog;

--- a/src/registerTools.ts
+++ b/src/registerTools.ts
@@ -12,11 +12,20 @@ type RegisterOptions = {
   toolsetGroup: ToolsetSource;
   prefix: string;
   onlyEnabled?: boolean;
-  handlerStrategy: (
+  /**
+   * Produces what the tool is registered with. Returning the schema instead of
+   * reading it back off the definition keeps the definition immutable, which is
+   * required now that one toolset group is shared across per-request servers.
+   */
+  prepareTool: (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tool: ToolDefinition<any, any> | DynamicToolDefinition<any>
+  ) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ) => (...args: any[]) => any;
+    schema: ToolDefinition<any, any>['schema'];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    handler: (...args: any[]) => any;
+  };
 };
 
 export function registerTools(
@@ -30,7 +39,7 @@ export function registerTools(
     server,
     toolsetGroup,
     prefix,
-    handlerStrategy: (tool) =>
+    prepareTool: (tool) =>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       composeToolHandler(tool as ToolDefinition<any, any>, {
         useFields,
@@ -50,7 +59,7 @@ export function registerDynamicTools(
     server,
     toolsetGroup: dynamicToolsetGroup,
     prefix,
-    handlerStrategy: (tool) => tool.handler,
+    prepareTool: (tool) => ({ schema: tool.schema, handler: tool.handler }),
   });
 }
 
@@ -58,7 +67,7 @@ function registerToolsets({
   server,
   toolsetGroup,
   prefix,
-  handlerStrategy,
+  prepareTool,
 }: RegisterOptions) {
   for (const toolset of toolsetGroup.toolsets) {
     if (!toolset.enabled) {
@@ -67,12 +76,12 @@ function registerToolsets({
 
     for (const tool of toolset.tools) {
       const toolNameWithPrefix = `${prefix}${tool.name}`;
-      const handler = handlerStrategy(tool);
+      const { schema, handler } = prepareTool(tool);
 
       server.registerOnce(
         toolNameWithPrefix,
         tool.description,
-        tool.schema,
+        schema,
         handler
       );
     }

--- a/src/registerTools.ts
+++ b/src/registerTools.ts
@@ -11,7 +11,6 @@ type RegisterOptions = {
   server: BacklogMCPServer;
   toolsetGroup: ToolsetSource;
   prefix: string;
-  onlyEnabled?: boolean;
   /**
    * Produces what the tool is registered with. Returning the schema instead of
    * reading it back off the definition keeps the definition immutable, which is

--- a/src/utils/backlogClientRegistry.test.ts
+++ b/src/utils/backlogClientRegistry.test.ts
@@ -47,7 +47,7 @@ describe('createBacklogClientRegistry', () => {
       registry.createScopedClient(),
       createTranslationHelper()
     );
-    const handler = composeToolHandler(tool, {
+    const { handler } = composeToolHandler(tool, {
       useFields: false,
       maxTokens: 5000,
     });
@@ -73,7 +73,7 @@ describe('createBacklogClientRegistry', () => {
       registry.createScopedClient(),
       createTranslationHelper()
     );
-    const handler = composeToolHandler(tool, {
+    const { handler } = composeToolHandler(tool, {
       useFields: false,
       maxTokens: 5000,
     });
@@ -101,7 +101,7 @@ describe('createBacklogClientRegistry', () => {
       registry.createScopedClient(),
       createTranslationHelper()
     );
-    const handler = composeToolHandler(tool, {
+    const { handler } = composeToolHandler(tool, {
       useFields: false,
       maxTokens: 5000,
     });
@@ -130,7 +130,7 @@ describe('createBacklogClientRegistry', () => {
       registry.createScopedClient(),
       createTranslationHelper()
     );
-    const handler = composeToolHandler(tool, {
+    const { handler } = composeToolHandler(tool, {
       useFields: false,
       maxTokens: 5000,
     });
@@ -209,7 +209,7 @@ describe('createBacklogClientRegistry', () => {
       registry.createScopedClient(),
       createTranslationHelper()
     );
-    const handler = composeToolHandler(tool, {
+    const { handler } = composeToolHandler(tool, {
       useFields: false,
       maxTokens: 5000,
     });
@@ -237,7 +237,7 @@ describe('createBacklogClientRegistry', () => {
       registry.createScopedClient(),
       createTranslationHelper()
     );
-    const handler = composeToolHandler(tool, {
+    const { handler } = composeToolHandler(tool, {
       useFields: false,
       maxTokens: 5000,
     });


### PR DESCRIPTION
Closes the measurement half of #174, and fixes the mutation that issue flags as prerequisite work.

## Measurement

Measured with a throwaway script (not committed — it stubbed the Backlog API at a configurable delay so construction and round trip were separable). Node 24, M-series Mac, 62 tools enabled:

**Per-request construction**

| | p50 | p95 |
|---|---|---|
| `createBacklogMcpServer()` | 2.0ms | 5.2ms |
| `createBacklogMcpServer()` with `--optimize-response` | 2.6ms | 6.0ms |

`registerTools()` is essentially all of it (p50 1.9ms). Within that, composing all 62 handlers is only ~0.5ms — the remaining ~1.4ms is the SDK's eager `standardSchemaToJsonSchema()` inside `registerTool`. `new McpServer()` is ~0.00ms. `buildToolsetGroup` is 1.9ms, but #173 already moved it off the request path.

**End-to-end `tools/call`**

| Backlog API latency | total p50 | construction | share |
|---|---|---|---|
| 0ms (stub) | 3.9ms | 2.9ms | 75% |
| 50ms | 55.8ms | 3.4ms | 6% |
| 200ms (typical SaaS) | 212ms | 8.3ms | 4% |

`tools/list` is 5.0ms and is almost all construction, but the 5-minute public cache hint from #173 keeps clients off it.

**Conclusion: the memoization sketched in step 2 of #174 is not worth doing.** Against a real Backlog round trip it buys a few percent of latency, and costs a cache that has to stay correct across `useFields` / `maxTokens` / `prefix` / translation state.

The one thing the numbers do surface is throughput rather than latency: those 2–3ms are *synchronous* event-loop time, so a single process ceilings around 400 req/s and concurrent requests head-of-line block on each other. That matters for a shared multi-tenant host, not for desktop or self-hosted use. Worth revisiting if this is ever deployed that way.

## Fix

Step 3 of #174: `composeToolHandler` extended `tool.schema` in place. That was harmless while each server built throwaway tool definitions, but #173 made one toolset group shared by every per-request server, so the mutation became cross-request — re-applied on every call, and visible to requests composing concurrently. It stayed correct only by the accident of `.extend()` being idempotent, which `src/dynamicToolsetPersistence.test.ts` had to pin explicitly.

- `composeToolHandler` returns `{ schema, handler }` and never touches the definition.
- `registerToolsets` takes a `prepareTool` yielding both, so registration no longer reads state back off the definition.
- The convergence test is replaced by one asserting the definitions come out of registration byte-identical (same `schema` object reference, unchanged shape).

Performance-neutral: A/B runs interleaved with `main` put `registerTools` at p50 1.88ms vs 1.99ms.

## Checks

`pnpm test` 444 passed · `typecheck` · `typecheck:all` · `lint` · `format` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)