### PR TITLE
feat: publish the tool layer as a library entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,19 @@
   "bin": {
     "backlog-mcp-server": "./build/index.js"
   },
+  "main": "./build/lib.js",
+  "types": "./build/lib.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib.d.ts",
+      "import": "./build/lib.js"
+    },
+    "./translation": {
+      "types": "./build/createTranslationHelper.d.ts",
+      "import": "./build/createTranslationHelper.js"
+    },
+    "./package.json": "./package.json"
+  },
   "engines": {
     "node": ">=22"
   },

--- a/src/handlers/builders/composeToolHandler.ts
+++ b/src/handlers/builders/composeToolHandler.ts
@@ -9,7 +9,7 @@ import { generateFieldsDescription } from '../../utils/generateFieldsDescription
 import { ErrorLike, SafeResult } from '../../types/result.js';
 import { ToolDefinition } from '../../types/tool.js';
 
-interface ComposeOptions {
+export interface ComposeOptions {
   useFields: boolean;
   errorHandler?: (err: unknown) => ErrorLike;
   maxTokens: number;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,37 @@
+/**
+ * Library entry point.
+ *
+ * `src/index.ts` is the CLI: it parses argv, reads config files and starts a
+ * transport. Consumers that only want the tool layer — to host the same tools on
+ * a different runtime, for example — cannot import it without running all of that.
+ * This module exposes the pieces needed to build a server, and nothing that runs
+ * on import.
+ *
+ * `createTranslationHelper` is deliberately not re-exported here even though
+ * `allTools` needs a `TranslationHelper`: it pulls in `cosmiconfig` and `node:os`,
+ * which are unavailable on non-Node runtimes such as Cloudflare Workers. Importing
+ * `allTools` must not drag them in. It is published under the `./translation`
+ * subpath instead, so consumers on Node can still use it while others supply their
+ * own implementation of the interface.
+ */
+
+export { allTools } from './tools/tools.js';
+export { composeToolHandler } from './handlers/builders/composeToolHandler.js';
+export { backlogErrorHandler } from './backlog/backlogErrorHandler.js';
+export { buildToolSchema } from './types/tool.js';
+export { isErrorLike } from './types/result.js';
+
+export type { ComposeOptions } from './handlers/builders/composeToolHandler.js';
+export type { TranslationHelper } from './createTranslationHelper.js';
+export type {
+  ToolDefinition,
+  DynamicToolDefinition,
+  ToolRegistrar,
+} from './types/tool.js';
+export type {
+  Toolset,
+  ToolsetGroup,
+  DynamicToolset,
+  DynamicToolsetGroup,
+} from './types/toolsets.js';
+export type { ErrorLike, SafeResult } from './types/result.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
       "moduleResolution": "NodeNext",
       "outDir": "./build",
       "rootDir": "./src",
+      "declaration": true,
       "strict": true,
       "esModuleInterop": true,
       "resolveJsonModule": true,


### PR DESCRIPTION
## Background

#13 asked for npm distribution and it was published — thank you. That covers the
CLI use case (`npx backlog-mcp-server`), but the package still cannot be imported:

```js
// backlog-mcp-server@0.15.0
import { allTools } from 'backlog-mcp-server';
// ERR_MODULE_NOT_FOUND: Cannot find package '.../backlog-mcp-server/index.js'
```

There is no `exports`, no `main`, no `types`, and `tsc` emits no declarations, so
Node resolves the package root and finds nothing. The real entry lives at
`build/index.js`, reachable only through `bin`. Installing succeeds, so the failure
only shows up at import time.

## Motivation

I wanted to host these tools on Cloudflare Workers. The tool factories in `src/tools/`
are a good fit — they are pure `(Backlog, TranslationHelper) => ToolDefinition`
functions with no Node dependencies, and `backlog-js` is fetch-based. Only the
transport and OAuth layers needed replacing.

But because the package cannot be imported, the only way to reuse those 62 tools is
to vendor the repository as a git submodule and hand-write `.d.ts` files for the
three functions I call. That copy silently goes stale, and re-declaring the types by
hand is exactly the kind of thing that breaks on a refactor here.

This PR makes the tool layer consumable without giving up the CLI.

## Changes

- **`src/lib.ts`** — a library entry that re-exports the public surface
- **`package.json`** — `exports`, `main`, `types`
- **`tsconfig.json`** — `declaration: true`
- **`ComposeOptions`** — now exported; calling `composeToolHandler` from outside
  requires naming its options type

## Design note: `createTranslationHelper` is on a subpath

`allTools` requires a `TranslationHelper`, so re-exporting `createTranslationHelper`
from the root would be the obvious thing to do. It is deliberately not:
`createTranslationHelper.ts` imports `cosmiconfig` and `node:os` at module scope, so
`import { allTools }` would pull both in and break on runtimes that lack them.

It is exported from `backlog-mcp-server/translation` instead. Node consumers keep it;
others implement the two-method interface themselves.

Verified by deleting cosmiconfig from a consumer's `node_modules`:

| import | result |
|---|---|
| `backlog-mcp-server` | resolves, 5 exports |
| `backlog-mcp-server/translation` | fails, as intended |

## Compatibility

No breaking change. `bin` is untouched, so `npx backlog-mcp-server` behaves exactly
as before. Nothing could have been importing the package root, because that has never
resolved.

## Verification

- Packed the tarball and installed it into a separate project, then type-checked and
  ran the real usage path (`allTools` → `composeToolHandler`): passes, with
  `ToolsetGroup` / `TranslationHelper` / `ComposeOptions` all resolving
- Runtime import returns the 5 expected exports
- Existing suite: **446 tests / 90 files pass**; lint and prettier clean

Happy to adjust the shape of the public surface — which symbols belong in it is your
call, and I can split the subpath differently if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)