### PR TITLE
refactor: keep Node-only config loading out of the translation helper

### DIFF
--- a/src/createTranslationHelper.test.ts
+++ b/src/createTranslationHelper.test.ts
@@ -1,55 +1,40 @@
 import { createTranslationHelper } from './createTranslationHelper';
-import { writeFileSync, unlinkSync } from 'fs';
-import { describe, it, expect, beforeEach } from 'vitest';
-import path from 'path';
-
-const TEMP_CONFIG_PATH = path.resolve(
-  process.cwd(),
-  '.backlog-mcp-serverrc.json'
-);
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 describe('createTranslationHelper', () => {
   beforeEach(() => {
     delete process.env.BACKLOG_MCP_HELLO;
-    try {
-      unlinkSync(TEMP_CONFIG_PATH);
-    } catch {
-      // noop: cannot do anything
-    }
   });
 
-  it('returns fallback if no env or config is present', () => {
-    const { t } = createTranslationHelper({ searchDir: process.cwd() });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns fallback if no env or override is present', () => {
+    const { t } = createTranslationHelper();
     expect(t('HELLO', 'Fallback')).toBe('Fallback');
   });
 
-  it('returns value from config file if present', () => {
-    writeFileSync(
-      TEMP_CONFIG_PATH,
-      JSON.stringify({ HELLO: 'From config' }, null, 2),
-      'utf-8'
-    );
-
-    const { t } = createTranslationHelper({ searchDir: process.cwd() });
+  it('returns value from overrides if present', () => {
+    const { t } = createTranslationHelper({ HELLO: 'From config' });
     expect(t('HELLO', 'Fallback')).toBe('From config');
   });
 
-  it('returns value from environment variable over config', () => {
-    writeFileSync(
-      TEMP_CONFIG_PATH,
-      JSON.stringify({ HELLO: 'From config' }, null, 2),
-      'utf-8'
-    );
-
+  it('returns value from environment variable over overrides', () => {
     process.env.BACKLOG_MCP_HELLO = 'From env';
 
-    const { t } = createTranslationHelper({ searchDir: process.cwd() });
+    const { t } = createTranslationHelper({ HELLO: 'From config' });
     expect(t('HELLO', 'Fallback')).toBe('From env');
+  });
+
+  it('looks up overrides by the upper-cased key', () => {
+    const { t } = createTranslationHelper({ HELLO: 'From config' });
+    expect(t('hello', 'Fallback')).toBe('From config');
   });
 
   it('caches the first call to a key', () => {
     process.env.BACKLOG_MCP_HELLO = 'Cached value';
-    const { t } = createTranslationHelper({ searchDir: process.cwd() });
+    const { t } = createTranslationHelper();
 
     const first = t('HELLO', 'Fallback');
     process.env.BACKLOG_MCP_HELLO = 'Modified value';
@@ -57,5 +42,33 @@ describe('createTranslationHelper', () => {
 
     expect(first).toBe('Cached value');
     expect(second).toBe('Cached value');
+  });
+
+  // The tool layer this helper serves is meant to run on non-Node runtimes, where
+  // `process` may be missing entirely or shimmed without `env`. Neither case is
+  // reachable on Node, so nothing else in the suite exercises these guards.
+  it('resolves without a process global', () => {
+    vi.stubGlobal('process', undefined);
+
+    const { t } = createTranslationHelper({ HELLO: 'From config' });
+    expect(t('HELLO', 'Fallback')).toBe('From config');
+    expect(t('MISSING', 'Fallback')).toBe('Fallback');
+  });
+
+  it('resolves when the process global has no env', () => {
+    vi.stubGlobal('process', {});
+
+    const { t } = createTranslationHelper({ HELLO: 'From config' });
+    expect(t('HELLO', 'From config')).toBe('From config');
+    expect(t('MISSING', 'Fallback')).toBe('Fallback');
+  });
+
+  it('dumps every key resolved so far', () => {
+    const { t, dump } = createTranslationHelper({ HELLO: 'From config' });
+
+    t('HELLO', 'Fallback');
+    t('GOODBYE', 'Bye');
+
+    expect(dump()).toEqual({ HELLO: 'From config', GOODBYE: 'Bye' });
   });
 });

--- a/src/createTranslationHelper.ts
+++ b/src/createTranslationHelper.ts
@@ -1,25 +1,22 @@
-import { cosmiconfigSync } from 'cosmiconfig';
-import os from 'os';
-
+/**
+ * Resolves the user-facing strings every tool definition passes through `t()`:
+ * tool descriptions and parameter descriptions.
+ *
+ * This module intentionally imports nothing. Every tool in `src/tools/` depends on
+ * it, so anything imported here is reachable from the tool layer — and the tool
+ * layer is meant to run on non-Node runtimes too. Discovering and reading the
+ * override file needs a filesystem and a home directory, so that part lives in
+ * `loadTranslationOverrides` and the CLI passes the result in.
+ */
 export interface TranslationHelper {
   t: (key: string, fallback: string) => string;
   dump: () => Record<string, string>;
 }
 
-export function createTranslationHelper(options?: {
-  configName?: string;
-  searchDir?: string;
-}): TranslationHelper {
+export function createTranslationHelper(
+  overrides: Record<string, string> = {}
+): TranslationHelper {
   const usedKeys: Record<string, string> = {};
-
-  const configName = options?.configName ?? 'backlog-mcp-server';
-
-  // Load config file
-  const explorer = cosmiconfigSync(configName);
-  const searchPath = options?.searchDir ?? os.homedir();
-
-  const configResult = explorer.search(searchPath);
-  const config = configResult?.config || {};
 
   function toEnvKey(key: string): string {
     return `BACKLOG_MCP_${key}`;
@@ -32,9 +29,13 @@ export function createTranslationHelper(options?: {
       return usedKeys[upperKey];
     }
 
-    // Priority：ENV → config → fallback
-    const value =
-      process.env[toEnvKey(upperKey)] || config[upperKey] || fallback;
+    // Runtimes without a Node compatibility layer have no `process`, and a
+    // partial shim can have `process` without `env`.
+    const env = typeof process === 'undefined' ? undefined : process.env;
+    const fromEnv = env?.[toEnvKey(upperKey)];
+
+    // Priority：ENV → overrides → fallback
+    const value = fromEnv || overrides[upperKey] || fallback;
 
     usedKeys[upperKey] = value;
     return value;

--- a/src/createTranslationHelper.ts
+++ b/src/createTranslationHelper.ts
@@ -1,6 +1,7 @@
 /**
- * Resolves the user-facing strings every tool definition passes through `t()`:
- * tool descriptions and parameter descriptions.
+ * Resolves the schema strings every tool definition passes through `t()`: tool
+ * descriptions and parameter descriptions. These are read by the model when it
+ * picks a tool and fills in arguments; they never reach the end user.
  *
  * This module intentionally imports nothing. Every tool in `src/tools/` depends on
  * it, so anything imported here is reachable from the tool layer — and the tool

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { hideBin } from 'yargs/helpers';
 import { getBacklogOAuthConfig } from './auth/backlogOAuthConfig.js';
 import { createTokenStore } from './auth/tokenStore.js';
 import { createTranslationHelper } from './createTranslationHelper.js';
+import { loadTranslationOverrides } from './loadTranslationOverrides.js';
 import { createBacklogMcpServer } from './createBacklogMcpServer.js';
 import { runHttpMcpServer } from './httpMcpServer.js';
 import {
@@ -149,7 +150,7 @@ if (tokenStore) {
 
 const useFields = argv.optimizeResponse;
 
-const transHelper = createTranslationHelper();
+const transHelper = createTranslationHelper(loadTranslationOverrides());
 
 const maxTokens = argv.maxTokens;
 const prefix = argv.prefix;

--- a/src/loadTranslationOverrides.test.ts
+++ b/src/loadTranslationOverrides.test.ts
@@ -1,0 +1,81 @@
+import { loadTranslationOverrides } from './loadTranslationOverrides';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+describe('loadTranslationOverrides', () => {
+  let searchDir: string;
+
+  beforeEach(() => {
+    searchDir = mkdtempSync(path.join(tmpdir(), 'backlog-mcp-rc-'));
+  });
+
+  afterEach(() => {
+    rmSync(searchDir, { recursive: true, force: true });
+  });
+
+  const writeConfig = (name: string, contents: string) =>
+    writeFileSync(path.join(searchDir, name), contents, 'utf-8');
+
+  it('returns an empty object when no config file is found', () => {
+    expect(loadTranslationOverrides({ searchDir })).toEqual({});
+  });
+
+  it('reads a JSON config file', () => {
+    writeConfig(
+      '.backlog-mcp-serverrc.json',
+      JSON.stringify({ HELLO: 'From json' })
+    );
+
+    expect(loadTranslationOverrides({ searchDir })).toEqual({
+      HELLO: 'From json',
+    });
+  });
+
+  it('reads a YAML config file', () => {
+    writeConfig('.backlog-mcp-serverrc.yaml', 'HELLO: From yaml\n');
+
+    expect(loadTranslationOverrides({ searchDir })).toEqual({
+      HELLO: 'From yaml',
+    });
+  });
+
+  it('returns an empty object when the config file is empty', () => {
+    writeConfig('.backlog-mcp-serverrc.json', '');
+
+    expect(loadTranslationOverrides({ searchDir })).toEqual({});
+  });
+
+  it('drops values that are not strings', () => {
+    writeConfig(
+      '.backlog-mcp-serverrc.json',
+      JSON.stringify({
+        KEPT: 'a string',
+        NUMBER: 12345,
+        ARRAY: ['a', 'b'],
+        OBJECT: { nested: 'value' },
+        NULL: null,
+        BOOLEAN: true,
+      })
+    );
+
+    expect(loadTranslationOverrides({ searchDir })).toEqual({
+      KEPT: 'a string',
+    });
+  });
+
+  it('returns an empty object when the config file is not an object', () => {
+    writeConfig('.backlog-mcp-serverrc.json', JSON.stringify(['a', 'b']));
+
+    expect(loadTranslationOverrides({ searchDir })).toEqual({});
+  });
+
+  it('honours a custom config name', () => {
+    writeConfig('.otherrc.json', JSON.stringify({ HELLO: 'From other' }));
+
+    expect(
+      loadTranslationOverrides({ searchDir, configName: 'other' })
+    ).toEqual({ HELLO: 'From other' });
+  });
+});

--- a/src/loadTranslationOverrides.ts
+++ b/src/loadTranslationOverrides.ts
@@ -1,0 +1,32 @@
+import { cosmiconfigSync } from 'cosmiconfig';
+import os from 'os';
+
+/**
+ * Reads description overrides from a `.backlog-mcp-serverrc` file (`.json`,
+ * `.yaml` or `.yml`) in the user's home directory.
+ *
+ * Node-only, and kept separate from `createTranslationHelper` for that reason:
+ * cosmiconfig walks the filesystem and the default search path is the home
+ * directory. The CLI calls this and hands the result to the helper.
+ *
+ * The file is user-authored, so its contents are unknown: anything that is not a
+ * string is dropped here rather than passed on. Every override ends up in a tool
+ * description, and a number or an array there would produce an invalid
+ * `tools/list` payload.
+ */
+export function loadTranslationOverrides(options?: {
+  configName?: string;
+  searchDir?: string;
+}): Record<string, string> {
+  const explorer = cosmiconfigSync(options?.configName ?? 'backlog-mcp-server');
+  const searchPath = options?.searchDir ?? os.homedir();
+
+  const config: unknown = explorer.search(searchPath)?.config;
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(config).filter(([, value]) => typeof value === 'string')
+  );
+}


### PR DESCRIPTION
## Problem

Every tool in `src/tools/` imports `createTranslationHelper` for its `TranslationHelper` type, which puts that module at the root of the tool layer's import graph. It also read the override file itself, so `cosmiconfig` and `node:os` were reachable from there.

That is harmless for the CLI, but it blocks reusing the tool layer on a runtime with no filesystem and no home directory — which is what #180 is asking for. Today those modules stay out of the emitted graph only because TypeScript elides the type-only imports. A single value import, or turning on `verbatimModuleSyntax`, would pull them back in, and nothing in the suite would notice.

## Changes

- **`src/loadTranslationOverrides.ts`** (new) — discovery and reading of `.backlog-mcp-serverrc`. `cosmiconfig` and `os` live here and nowhere else.
- **`src/createTranslationHelper.ts`** — takes the overrides as an argument. It now imports nothing at all. The `process` lookup is guarded, since a runtime without Node built-ins may have no `process` global, or a shim without `env`.
- **`src/index.ts`** — one line wires the two together.
- Non-string config values are dropped while reading rather than passed on. The file is user-authored, every override ends up in a tool description, and a number there produced a non-string `description` in `tools/list`.

Resolution order (ENV → config file → fallback) and `--export-translations` are unchanged. No user-visible behaviour change, so the README needs no edit.

## Verification

Module graph after building, walked from each entry point:

| entry | reaches `cosmiconfig` / `os` |
|---|---|
| `build/createTranslationHelper.js` | no — 1 file walked, zero imports |
| `build/tools/tools.js` (`allTools`) | no — 68 files walked |
| `build/index.js` (CLI) | yes, via `./loadTranslationOverrides.js` — as intended |

Behaviour, against a running server:

- `~/.backlog-mcp-serverrc.json` override applies; `BACKLOG_MCP_*` still wins over it
- `--export-translations` dumps the same 355 keys
- a numeric override value is now ignored and falls back to English, instead of emitting `12345` as a description

Suite: **457 tests / 91 files pass** (446 before), `typecheck:all`, lint and prettier clean. The two `process`-guard tests were checked against a reverted guard and fail with distinct errors for the missing-`process` and missing-`env` cases.

## Relation to #180

This removes the reason for that PR's `./translation` subpath: once `createTranslationHelper` is runtime-agnostic, it can be exported from the library root like anything else. Happy to sequence this either way — after #180 merges I can rebase and follow up there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)