### PR TITLE
chore: drop the ./translation subpath now that the root can carry it

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
       "types": "./build/lib.d.ts",
       "import": "./build/lib.js"
     },
-    "./translation": {
-      "types": "./build/createTranslationHelper.d.ts",
-      "import": "./build/createTranslationHelper.js"
-    },
     "./package.json": "./package.json"
   },
   "engines": {

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,0 +1,66 @@
+import * as lib from './lib';
+import { describe, it, expect } from 'vitest';
+import type { z } from 'zod';
+import type {
+  ComposeOptions,
+  DynamicToolDefinition,
+  DynamicToolset,
+  DynamicToolsetGroup,
+  ErrorLike,
+  SafeResult,
+  ToolDefinition,
+  ToolRegistrar,
+  Toolset,
+  ToolsetGroup,
+  TranslationHelper,
+} from './lib';
+
+/**
+ * `package.json`'s `exports` field makes this module the package's public API, so
+ * anything here is a compatibility promise. These tests exist to make a change to
+ * that surface deliberate: adding an export means updating the list below, and
+ * dropping one fails here instead of in a consumer's build.
+ */
+describe('library entry point', () => {
+  it('exports exactly the documented runtime surface', () => {
+    expect(Object.keys(lib).sort()).toEqual([
+      'allTools',
+      'backlogErrorHandler',
+      'buildToolSchema',
+      'composeToolHandler',
+      'createTranslationHelper',
+      'isErrorLike',
+    ]);
+  });
+
+  it('exports every runtime symbol as a function', () => {
+    for (const [name, value] of Object.entries(lib)) {
+      expect(typeof value, name).toBe('function');
+    }
+  });
+
+  // Types vanish at runtime, so the check has to happen at compile time: this fails
+  // `typecheck:all` if any of them stops being exported.
+  it('exports the documented types', () => {
+    const types: [
+      ComposeOptions?,
+      DynamicToolDefinition<z.ZodRawShape>?,
+      DynamicToolset?,
+      DynamicToolsetGroup?,
+      ErrorLike?,
+      SafeResult<unknown>?,
+      ToolDefinition<z.ZodRawShape, z.ZodRawShape>?,
+      ToolRegistrar?,
+      Toolset?,
+      ToolsetGroup?,
+      TranslationHelper?,
+    ] = [];
+
+    expect(types).toEqual([]);
+  });
+
+  it('does not leak the Node-only override loader', () => {
+    // It reads from disk, which would defeat the point of this entry point.
+    expect(lib).not.toHaveProperty('loadTranslationOverrides');
+  });
+});

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,16 +7,15 @@
  * This module exposes the pieces needed to build a server, and nothing that runs
  * on import.
  *
- * `createTranslationHelper` is deliberately not re-exported here even though
- * `allTools` needs a `TranslationHelper`: it pulls in `cosmiconfig` and `node:os`,
- * which are unavailable on non-Node runtimes such as Cloudflare Workers. Importing
- * `allTools` must not drag them in. It is published under the `./translation`
- * subpath instead, so consumers on Node can still use it while others supply their
- * own implementation of the interface.
+ * Nothing reachable from here may touch a Node built-in. `loadTranslationOverrides`
+ * is the counter-example worth remembering: it reads the override file from disk,
+ * so it belongs to the CLI and is deliberately absent below. Consumers on other
+ * runtimes pass their own overrides to `createTranslationHelper`.
  */
 
 export { allTools } from './tools/tools.js';
 export { composeToolHandler } from './handlers/builders/composeToolHandler.js';
+export { createTranslationHelper } from './createTranslationHelper.js';
 export { backlogErrorHandler } from './backlog/backlogErrorHandler.js';
 export { buildToolSchema } from './types/tool.js';
 export { isErrorLike } from './types/result.js';


### PR DESCRIPTION
Follow-up to #180 and #181.

## Why

#180 routed `createTranslationHelper` through a `./translation` subpath because that module imported `cosmiconfig` and `node:os`, which would otherwise have been reachable from every consumer of `allTools`. #181 moved the file reading out into `loadTranslationOverrides`, so the helper now imports nothing at all — the root entry can export it like anything else, and the Design note in `src/lib.ts` explaining the split no longer described the code.

**Removing the subpath is free right now.** `0.15.0` on npm predates the `exports` field, so `backlog-mcp-server/translation` has never resolved for anyone:

```
$ npm view backlog-mcp-server version   → 0.15.0
$ npm view backlog-mcp-server exports   → (none)
```

Once published it becomes a path we cannot take back without a breaking change, so this wants to land before the next release.

## Changes

- `package.json` — drop the `./translation` entry from `exports`
- `src/lib.ts` — export `createTranslationHelper` from the root; replace the Design note with the invariant that actually still holds (nothing reachable from here may touch a Node built-in, with `loadTranslationOverrides` as the counter-example)
- `src/lib.test.ts` (new) — pin the public surface

## The surface test

This was the open item from #180's review. `exports` makes `src/lib.ts` the package's compatibility promise, and nothing was pinning it — dropping a symbol during a refactor would have surfaced in a consumer's build rather than in CI. Four checks:

- the runtime export list, exactly
- every runtime export is a function
- the exported *types* are referenced in a tuple, so removing one fails `typecheck:all` (types leave no runtime trace to assert on)
- `loadTranslationOverrides` is absent, since it reads from disk

## Verification

Packed the tarball and installed it into a separate project:

```
exports: allTools, backlogErrorHandler, buildToolSchema, composeToolHandler,
         createTranslationHelper, isErrorLike
t():     ルートから上書き                        ← overrides applied through the root export

import('backlog-mcp-server/translation')
  → ERR_PACKAGE_PATH_NOT_EXPORTED                ← as intended

build/lib.d.ts present
```

Suite: **461 tests / 92 files pass**, `typecheck:all`, lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)