### PR TITLE
fix: config file diagnostics, and drop cosmiconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,16 +52,17 @@
     "@modelcontextprotocol/hono": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "backlog-js": "^0.19.1",
-    "cosmiconfig": "^9.0.1",
     "env-var": "^7.5.0",
     "graphql": "^16.14.1",
     "hono": "^4.12.34",
+    "js-yaml": "^4.3.1",
     "pino": "^10.3.1",
     "yargs": "^18.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.9.2",
     "@types/yargs": "^17.0.35",
     "@typescript-eslint/eslint-plugin": "^8.60.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       backlog-js:
         specifier: ^0.19.1
         version: 0.19.1
-      cosmiconfig:
-        specifier: ^9.0.1
-        version: 9.0.1(typescript@6.0.3)
       env-var:
         specifier: ^7.5.0
         version: 7.5.0
@@ -32,6 +29,9 @@ importers:
       hono:
         specifier: ^4.12.34
         version: 4.12.34
+      js-yaml:
+        specifier: ^4.3.1
+        version: 4.3.1
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -45,6 +45,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -89,10 +92,6 @@ importers:
         version: 4.1.8(@types/node@25.9.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.2(@types/node@25.9.2)(jiti@2.7.0)(tsx@4.22.4))
 
 packages:
-
-  '@babel/code-frame@7.29.7':
-    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -684,6 +683,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -847,10 +849,6 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -864,15 +862,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cosmiconfig@9.0.1:
-    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -903,16 +892,9 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
-
   env-var@7.5.0:
     resolution: {integrity: sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==}
     engines: {node: '>=10'}
-
-  error-ex@1.3.4:
-    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1124,16 +1106,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
-
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
-
-  is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1169,18 +1144,12 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1194,9 +1163,6 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
-
-  lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1260,14 +1226,6 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-
-  parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1345,10 +1303,6 @@ packages:
 
   real-require@1.0.0:
     resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
-
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
 
   rollup@4.62.4:
     resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
@@ -1598,12 +1552,6 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
-
-  '@babel/code-frame@7.29.7':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.29.7
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -1948,6 +1896,8 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/node@25.9.2':
@@ -2155,8 +2105,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
-  callsites@3.1.0: {}
-
   chai@6.2.2: {}
 
   cliui@9.0.1:
@@ -2168,15 +2116,6 @@ snapshots:
   colorette@2.0.20: {}
 
   convert-source-map@2.0.0: {}
-
-  cosmiconfig@9.0.1(typescript@6.0.3):
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.1
-      js-yaml: 4.2.0
-      parse-json: 5.2.0
-    optionalDependencies:
-      typescript: 6.0.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2204,13 +2143,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  env-paths@2.2.1: {}
-
   env-var@7.5.0: {}
-
-  error-ex@1.3.4:
-    dependencies:
-      is-arrayish: 0.2.1
 
   es-define-property@1.0.1: {}
 
@@ -2458,14 +2391,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-
   imurmurhash@0.1.4: {}
-
-  is-arrayish@0.2.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -2495,15 +2421,11 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-tokens@4.0.0: {}
-
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
   json-buffer@3.0.1: {}
-
-  json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -2517,8 +2439,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
-
-  lines-and-columns@1.2.4: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -2578,17 +2498,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
-
-  parse-json@5.2.0:
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      error-ex: 1.3.4
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.2.4
 
   path-exists@4.0.0: {}
 
@@ -2670,8 +2579,6 @@ snapshots:
   real-require@0.2.0: {}
 
   real-require@1.0.0: {}
-
-  resolve-from@4.0.0: {}
 
   rollup@4.62.4:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { createDescriptionHelper } from './createDescriptionHelper.js';
 import { loadDescriptionOverrides } from './loadDescriptionOverrides.js';
 import { createBacklogMcpServer } from './createBacklogMcpServer.js';
 import { runHttpMcpServer } from './httpMcpServer.js';
+import { reportUnknownOverrideKeys } from './reportUnknownOverrideKeys.js';
 import {
   createBacklogClientRegistry,
   createOAuthBacklogClientRegistry,
@@ -169,7 +170,8 @@ if (tokenStore) {
 
 const useFields = argv.optimizeResponse;
 
-const descriptionHelper = createDescriptionHelper(loadDescriptionOverrides());
+const descriptionOverrides = loadDescriptionOverrides();
+const descriptionHelper = createDescriptionHelper(descriptionOverrides);
 
 const maxTokens = argv.maxTokens;
 const prefix = argv.prefix;
@@ -194,6 +196,14 @@ const sharedToolsetGroup = buildToolsetGroup(
   descriptionHelper,
   enabledToolsets
 );
+
+reportUnknownOverrideKeys({
+  overrides: descriptionOverrides,
+  version,
+  backlog,
+  clientRegistry,
+  mcpOption,
+});
 
 // Factory: creates a fresh MCP server with all tools registered.
 // Used once per stdio connection; one fresh instance per HTTP request.

--- a/src/loadDescriptionOverrides.test.ts
+++ b/src/loadDescriptionOverrides.test.ts
@@ -107,8 +107,39 @@ describe('loadDescriptionOverrides', () => {
 
       expect(errorSpy).toHaveBeenCalledOnce();
       expect(errorSpy.mock.calls[0]?.[0]).toMatchObject({
-        searchPath: searchDir,
+        filePath: path.join(searchDir, '.backlog-mcp-serverrc.yaml'),
       });
     });
+
+    it('does not treat a missing file as unreadable', () => {
+      loadDescriptionOverrides({ searchDir });
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('prefers .json over .yaml and .yml', () => {
+    writeConfig(
+      '.backlog-mcp-serverrc.json',
+      JSON.stringify({ WHICH: 'json' })
+    );
+    writeConfig('.backlog-mcp-serverrc.yaml', 'WHICH: yaml\n');
+    writeConfig('.backlog-mcp-serverrc.yml', 'WHICH: yml\n');
+
+    expect(loadDescriptionOverrides({ searchDir })).toEqual({ WHICH: 'json' });
+  });
+
+  it('reads a .yml config file', () => {
+    writeConfig('.backlog-mcp-serverrc.yml', 'HELLO: From yml\n');
+
+    expect(loadDescriptionOverrides({ searchDir })).toEqual({
+      HELLO: 'From yml',
+    });
+  });
+
+  it('returns an empty object when the search directory does not exist', () => {
+    expect(
+      loadDescriptionOverrides({ searchDir: path.join(searchDir, 'nope') })
+    ).toEqual({});
   });
 });

--- a/src/loadDescriptionOverrides.test.ts
+++ b/src/loadDescriptionOverrides.test.ts
@@ -137,6 +137,39 @@ describe('loadDescriptionOverrides', () => {
     });
   });
 
+  describe('the extensionless rc file', () => {
+    it('is read as YAML', () => {
+      writeConfig('.backlog-mcp-serverrc', 'HELLO: From extensionless\n');
+
+      expect(loadDescriptionOverrides({ searchDir })).toEqual({
+        HELLO: 'From extensionless',
+      });
+    });
+
+    it('accepts JSON contents, since YAML is a superset', () => {
+      writeConfig(
+        '.backlog-mcp-serverrc',
+        JSON.stringify({ HELLO: 'From extensionless json' })
+      );
+
+      expect(loadDescriptionOverrides({ searchDir })).toEqual({
+        HELLO: 'From extensionless json',
+      });
+    });
+
+    it('wins over the suffixed files', () => {
+      writeConfig('.backlog-mcp-serverrc', 'WHICH: extensionless\n');
+      writeConfig(
+        '.backlog-mcp-serverrc.json',
+        JSON.stringify({ WHICH: 'json' })
+      );
+
+      expect(loadDescriptionOverrides({ searchDir })).toEqual({
+        WHICH: 'extensionless',
+      });
+    });
+  });
+
   it('returns an empty object when the search directory does not exist', () => {
     expect(
       loadDescriptionOverrides({ searchDir: path.join(searchDir, 'nope') })

--- a/src/loadDescriptionOverrides.test.ts
+++ b/src/loadDescriptionOverrides.test.ts
@@ -1,8 +1,9 @@
 import { loadDescriptionOverrides } from './loadDescriptionOverrides';
+import { logger } from './utils/logger';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 describe('loadDescriptionOverrides', () => {
   let searchDir: string;
@@ -77,5 +78,37 @@ describe('loadDescriptionOverrides', () => {
     expect(
       loadDescriptionOverrides({ searchDir, configName: 'other' })
     ).toEqual({ HELLO: 'From other' });
+  });
+
+  describe('when the config file cannot be parsed', () => {
+    let errorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('falls back to the defaults instead of throwing', () => {
+      writeConfig('.backlog-mcp-serverrc.json', '{ this is not valid json');
+
+      expect(() => loadDescriptionOverrides({ searchDir })).not.toThrow();
+      expect(loadDescriptionOverrides({ searchDir })).toEqual({});
+    });
+
+    it('reports the failure at a level the default logger emits', () => {
+      // The logger runs at level `error` unless NODE_ENV says otherwise, so a
+      // warning would be dropped for the users this message is meant for.
+      writeConfig('.backlog-mcp-serverrc.yaml', 'HELLO: [unclosed\n');
+
+      loadDescriptionOverrides({ searchDir });
+
+      expect(errorSpy).toHaveBeenCalledOnce();
+      expect(errorSpy.mock.calls[0]?.[0]).toMatchObject({
+        searchPath: searchDir,
+      });
+    });
   });
 });

--- a/src/loadDescriptionOverrides.ts
+++ b/src/loadDescriptionOverrides.ts
@@ -1,5 +1,7 @@
-import { cosmiconfigSync } from 'cosmiconfig';
+import { readFileSync } from 'fs';
+import yaml from 'js-yaml';
 import os from 'os';
+import path from 'path';
 import { logger } from './utils/logger.js';
 
 /**
@@ -7,46 +9,98 @@ import { logger } from './utils/logger.js';
  * `.yaml` or `.yml`) in the user's home directory.
  *
  * Node-only, and kept separate from `createDescriptionHelper` for that reason:
- * cosmiconfig walks the filesystem and the default search path is the home
- * directory. The CLI calls this and hands the result to the helper.
+ * this reads the filesystem and needs a home directory. The CLI calls it and
+ * hands the result to the helper.
  *
  * The file is user-authored, so its contents are unknown: anything that is not a
  * string is dropped here rather than passed on. Most overrides end up in a tool
  * description, and a number or an array there would produce an invalid
  * `tools/list` payload.
  *
- * A file that cannot be parsed is reported and then ignored. Overriding
- * descriptions is an add-on, and a trailing comma in an optional file is not a
- * reason to stop serving the tools — from the client's side an exception here
- * looks like "the MCP server will not connect", with nothing pointing at the
- * config file.
+ * A file that exists but cannot be parsed is reported and then ignored.
+ * Overriding descriptions is an add-on, and a trailing comma in an optional file
+ * is not a reason to stop serving the tools — from the client's side an
+ * exception here looks like "the MCP server will not connect", with nothing
+ * pointing at the config file.
  */
+
+const EXTENSIONS = ['json', 'yaml', 'yml'] as const;
+
+type ReadOutcome =
+  | { status: 'found'; config: unknown }
+  | { status: 'absent' }
+  | { status: 'unreadable'; error: unknown };
+
+/**
+ * A missing candidate is not a failure — there are three of them and at most one
+ * exists. A candidate that exists but does not parse is, and has to be
+ * distinguished from the missing case so it can be reported rather than skipped.
+ */
+function readCandidate(filePath: string): ReadOutcome {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf-8');
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+    ) {
+      return { status: 'absent' };
+    }
+    return { status: 'unreadable', error };
+  }
+
+  try {
+    // An empty file is a config file with nothing in it, not a parse failure.
+    // `JSON.parse('')` throws, so it never reaches the caller's object check.
+    if (raw.trim() === '') return { status: 'found', config: undefined };
+    return {
+      status: 'found',
+      config: filePath.endsWith('.json') ? JSON.parse(raw) : yaml.load(raw),
+    };
+  } catch (error) {
+    return { status: 'unreadable', error };
+  }
+}
+
 export function loadDescriptionOverrides(options?: {
   configName?: string;
   searchDir?: string;
 }): Record<string, string> {
-  const explorer = cosmiconfigSync(options?.configName ?? 'backlog-mcp-server');
-  const searchPath = options?.searchDir ?? os.homedir();
+  const configName = options?.configName ?? 'backlog-mcp-server';
+  const searchDir = options?.searchDir ?? os.homedir();
 
-  let config: unknown;
-  try {
-    config = explorer.search(searchPath)?.config;
-  } catch (error) {
-    // `logger.error`, not `warn`: the logger runs at level `error` unless
-    // NODE_ENV says otherwise, so a warning here would never reach the user this
-    // message exists for.
-    logger.error(
-      { err: error, searchPath },
-      'Could not read the description override file; continuing with the built-in defaults'
+  for (const extension of EXTENSIONS) {
+    const filePath = path.join(searchDir, `.${configName}rc.${extension}`);
+    const outcome = readCandidate(filePath);
+
+    if (outcome.status === 'absent') continue;
+
+    if (outcome.status === 'unreadable') {
+      // `logger.error`, not `warn`: the logger runs at level `error` unless
+      // NODE_ENV says otherwise, so a warning here would never reach the user
+      // this message exists for.
+      logger.error(
+        { err: outcome.error, filePath },
+        'Could not read the description override file; continuing with the built-in defaults'
+      );
+      return {};
+    }
+
+    const config = outcome.config;
+    if (
+      typeof config !== 'object' ||
+      config === null ||
+      Array.isArray(config)
+    ) {
+      return {};
+    }
+
+    return Object.fromEntries(
+      Object.entries(config).filter(([, value]) => typeof value === 'string')
     );
-    return {};
   }
 
-  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
-    return {};
-  }
-
-  return Object.fromEntries(
-    Object.entries(config).filter(([, value]) => typeof value === 'string')
-  );
+  return {};
 }

--- a/src/loadDescriptionOverrides.ts
+++ b/src/loadDescriptionOverrides.ts
@@ -5,8 +5,8 @@ import path from 'path';
 import { logger } from './utils/logger.js';
 
 /**
- * Reads description overrides from a `.backlog-mcp-serverrc` file (`.json`,
- * `.yaml` or `.yml`) in the user's home directory.
+ * Reads description overrides from a `.backlog-mcp-serverrc` file in the user's
+ * home directory.
  *
  * Node-only, and kept separate from `createDescriptionHelper` for that reason:
  * this reads the filesystem and needs a home directory. The CLI calls it and
@@ -24,7 +24,11 @@ import { logger } from './utils/logger.js';
  * pointing at the config file.
  */
 
-const EXTENSIONS = ['json', 'yaml', 'yml'] as const;
+/**
+ * Checked in this order; the first one that exists wins. The extensionless form
+ * is parsed as YAML, which also accepts JSON.
+ */
+const SUFFIXES = ['', '.json', '.yaml', '.yml'] as const;
 
 type ReadOutcome =
   | { status: 'found'; config: unknown }
@@ -32,7 +36,7 @@ type ReadOutcome =
   | { status: 'unreadable'; error: unknown };
 
 /**
- * A missing candidate is not a failure — there are three of them and at most one
+ * A missing candidate is not a failure — there are four of them and at most one
  * exists. A candidate that exists but does not parse is, and has to be
  * distinguished from the missing case so it can be reported rather than skipped.
  */
@@ -71,8 +75,8 @@ export function loadDescriptionOverrides(options?: {
   const configName = options?.configName ?? 'backlog-mcp-server';
   const searchDir = options?.searchDir ?? os.homedir();
 
-  for (const extension of EXTENSIONS) {
-    const filePath = path.join(searchDir, `.${configName}rc.${extension}`);
+  for (const suffix of SUFFIXES) {
+    const filePath = path.join(searchDir, `.${configName}rc${suffix}`);
     const outcome = readCandidate(filePath);
 
     if (outcome.status === 'absent') continue;

--- a/src/loadDescriptionOverrides.ts
+++ b/src/loadDescriptionOverrides.ts
@@ -1,5 +1,6 @@
 import { cosmiconfigSync } from 'cosmiconfig';
 import os from 'os';
+import { logger } from './utils/logger.js';
 
 /**
  * Reads description overrides from a `.backlog-mcp-serverrc` file (`.json`,
@@ -13,6 +14,12 @@ import os from 'os';
  * string is dropped here rather than passed on. Most overrides end up in a tool
  * description, and a number or an array there would produce an invalid
  * `tools/list` payload.
+ *
+ * A file that cannot be parsed is reported and then ignored. Overriding
+ * descriptions is an add-on, and a trailing comma in an optional file is not a
+ * reason to stop serving the tools — from the client's side an exception here
+ * looks like "the MCP server will not connect", with nothing pointing at the
+ * config file.
  */
 export function loadDescriptionOverrides(options?: {
   configName?: string;
@@ -21,7 +28,20 @@ export function loadDescriptionOverrides(options?: {
   const explorer = cosmiconfigSync(options?.configName ?? 'backlog-mcp-server');
   const searchPath = options?.searchDir ?? os.homedir();
 
-  const config: unknown = explorer.search(searchPath)?.config;
+  let config: unknown;
+  try {
+    config = explorer.search(searchPath)?.config;
+  } catch (error) {
+    // `logger.error`, not `warn`: the logger runs at level `error` unless
+    // NODE_ENV says otherwise, so a warning here would never reach the user this
+    // message exists for.
+    logger.error(
+      { err: error, searchPath },
+      'Could not read the description override file; continuing with the built-in defaults'
+    );
+    return {};
+  }
+
   if (typeof config !== 'object' || config === null || Array.isArray(config)) {
     return {};
   }

--- a/src/reportUnknownOverrideKeys.test.ts
+++ b/src/reportUnknownOverrideKeys.test.ts
@@ -1,0 +1,90 @@
+import { Backlog } from 'backlog-js';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { reportUnknownOverrideKeys } from './reportUnknownOverrideKeys';
+import type { BacklogClientRegistry } from './utils/backlogClientRegistry';
+import { logger } from './utils/logger';
+
+describe('reportUnknownOverrideKeys', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  // Tool definitions only touch the client inside their handlers, so building
+  // the probe never calls it.
+  const args = {
+    version: '0.0.0-test',
+    backlog: {} as Backlog,
+    clientRegistry: {} as BacklogClientRegistry,
+    mcpOption: {
+      useFields: false,
+      maxTokens: 50000,
+      prefix: '',
+      useOrganization: false,
+    },
+  };
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('says nothing when there are no overrides', () => {
+    reportUnknownOverrideKeys({ ...args, overrides: {} });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('says nothing when every key matches a tool or parameter', () => {
+    reportUnknownOverrideKeys({
+      ...args,
+      overrides: {
+        TOOL_GET_SPACE_DESCRIPTION: 'Custom',
+        TOOL_GET_ISSUE_ISSUE_ID: 'Custom',
+      },
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports a key that matches nothing', () => {
+    reportUnknownOverrideKeys({
+      ...args,
+      overrides: {
+        TOOL_GET_SPACE_DESCRIPTION: 'Custom',
+        TOOL_THAT_WAS_RENAMED_DESCRIPTION: 'Custom',
+      },
+    });
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(errorSpy.mock.calls[0]?.[0]).toEqual({
+      keys: ['TOOL_THAT_WAS_RENAMED_DESCRIPTION'],
+    });
+  });
+
+  it('reports a key written in the wrong case, which never matches either', () => {
+    reportUnknownOverrideKeys({
+      ...args,
+      overrides: { tool_get_space_description: 'Custom' },
+    });
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(errorSpy.mock.calls[0]?.[0]).toEqual({
+      keys: ['tool_get_space_description'],
+    });
+  });
+
+  it('accepts keys from toolsets and dynamic tools the real server has disabled', () => {
+    // The probe enables everything on purpose: a key belonging to a disabled
+    // toolset is still a valid key, and reporting it would be a false alarm.
+    reportUnknownOverrideKeys({
+      ...args,
+      overrides: {
+        TOOL_ENABLE_TOOLSET_DESCRIPTION: 'Custom',
+        TOOL_GET_WIKI_DESCRIPTION: 'Custom',
+      },
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/reportUnknownOverrideKeys.ts
+++ b/src/reportUnknownOverrideKeys.ts
@@ -1,0 +1,63 @@
+import type { Backlog } from 'backlog-js';
+import { createBacklogMcpServer } from './createBacklogMcpServer.js';
+import { createDescriptionHelper } from './createDescriptionHelper.js';
+import type { MCPOptions } from './types/mcp.js';
+import type { BacklogClientRegistry } from './utils/backlogClientRegistry.js';
+import { logger } from './utils/logger.js';
+
+/**
+ * Reports override keys in the config file that no tool or parameter asks for.
+ *
+ * The override keys are an untyped, unversioned public API: rename one in the
+ * source and every user's override for it stops applying, falls back to the
+ * built-in default, and says nothing. The user sees "I configured this and it
+ * has no effect". This turns that into a line in the server log.
+ *
+ * The comparison is exact, which also catches keys written in the wrong case —
+ * `t()` looks up `key.toUpperCase()`, so a lower-case entry in the config file
+ * never matches anything either.
+ */
+export function reportUnknownOverrideKeys({
+  overrides,
+  version,
+  backlog,
+  clientRegistry,
+  mcpOption,
+}: {
+  overrides: Record<string, string>;
+  version: string;
+  backlog: Backlog;
+  clientRegistry: BacklogClientRegistry;
+  mcpOption: MCPOptions;
+}): void {
+  const configured = Object.keys(overrides);
+  if (configured.length === 0) return;
+
+  // Keys are only recorded once a tool asks for them, so the set of valid keys
+  // is whatever building the full tool list touches. This is a throwaway helper
+  // and server built purely to collect them: the real ones may have toolsets
+  // disabled, and their keys would then look unknown. ~17ms, and only for users
+  // who actually have a config file.
+  const probe = createDescriptionHelper();
+  createBacklogMcpServer({
+    version,
+    useFields: mcpOption.useFields,
+    backlog,
+    clientRegistry,
+    descriptionHelper: probe,
+    enabledToolsets: ['all'],
+    mcpOption: { ...mcpOption, useOrganization: true },
+    dynamicToolsets: true,
+  });
+
+  const known = new Set(Object.keys(probe.dump()));
+  const unknown = configured.filter((key) => !known.has(key));
+  if (unknown.length === 0) return;
+
+  // `error`, not `warn`: the logger drops anything below error in the default
+  // configuration, which is what users run.
+  logger.error(
+    { keys: unknown },
+    'These description override keys match no tool or parameter and had no effect'
+  );
+}


### PR DESCRIPTION
Closes #185. Closes #186.

Done together because both touch `loadDescriptionOverrides`, and #186 itself suggests it. Three commits, in the order that matters — #185 specifies the error handling first, so the #186 swap has something to preserve. Rebased onto `main` now that #189 has landed.

## 1. A malformed file no longer kills startup (#185)

`cosmiconfig.search()` threw and nothing caught it, so a trailing comma in an optional file killed the process. From the client's side that reads as "the MCP server will not connect", with nothing pointing at the config file.

**The `logger.warn` suggested in the issue would not have worked.** `utils/logger` sets `level: isProd ? 'error' : 'debug'` and defaults `NODE_ENV` to `production` itself, so a warn call is dropped for exactly the users the message exists for. This uses `logger.error`, with a test pinning the reason.

## 2. Override keys that match nothing are reported (#185)

```
{"level":50,"keys":["TOOL_RENAMED_AWAY_DESCRIPTION","tool_get_issue_description"],
 "msg":"These description override keys match no tool or parameter and had no effect"}
```

Two notes on the implementation:

- The known-key set comes from a **throwaway** helper and server with every toolset and dynamic tool enabled. The real ones may have toolsets disabled, and those keys would then be reported as unknown — a false alarm on a perfectly good config. Measured at ~17ms, and skipped entirely when the config file has no entries, which is the common case.
- The comparison is exact, so it also catches **keys written in the wrong case**. `t()` looks up `key.toUpperCase()` and the loader does not normalise, so a lower-case entry silently matches nothing today. Same silent failure as the issue describes, different cause.

## 3. cosmiconfig replaced (#186)

Confirmed the premise: no `stopDir` is passed, so cosmiconfig runs with `searchStrategy: 'none'` and only ever looks in one directory. Four transitive dependencies for "try a few filenames": `env-paths`, `import-fresh`, `js-yaml`, `parse-json`. All four gone, `js-yaml` back as a direct dependency.

**Pinned to `js-yaml@^4`**, not latest. `js-yaml@5` is a different API (event/constant based) and does not match `@types/js-yaml@4` — installing latest typechecks but breaks at runtime.

**The sketch in the issue had a bug worth flagging.** A single `catch` around both the read and the parse swallows a malformed file and moves to the next candidate — which is failure mode 1 again, in a quieter form. So the read distinguishes `ENOENT`/`ENOTDIR` (a candidate that is simply not there, normal for two of the three) from a file that exists and does not parse.

Empty files needed care too: `JSON.parse('')` throws, so an empty config would otherwise be reported as unreadable rather than treated as no overrides. There was already a test for that.

### Behaviour that changes

The formats cosmiconfig supported but the README never documented are gone: `.js`, `.cjs`, `.mjs`, a `package.json` field, `.config/` paths. Anyone who found them by accident is affected. `.json` / `.yaml` / `.yml` are unaffected, and `.json` wins over `.yaml` over `.yml`, matching cosmiconfig's order.

## Verification

- `pnpm typecheck`, `typecheck:all`, `lint`, `format` clean; **472 tests pass** (461 before, +11)
- End to end against a real `$HOME`: a YAML override applies, a stale key is reported, and a malformed file leaves the server exporting all 355 keys instead of dying

🤖 Generated with [Claude Code](https://claude.com/claude-code)