### PR TITLE
fix: rename the addDocument tool to add_document

### DIFF
--- a/src/tools/addDocument.ts
+++ b/src/tools/addDocument.ts
@@ -39,7 +39,7 @@ export const addDocumentTool = (
   Entity.Document.Document
 > => {
   return {
-    name: 'addDocument',
+    name: 'add_document',
     description: t(
       'TOOL_ADD_DOCUMENT_DESCRIPTION',
       'Adds a new document to the specified project.'

--- a/src/tools/tools.test.ts
+++ b/src/tools/tools.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { allTools } from './tools.js';
+import { createDescriptionHelper } from '../createDescriptionHelper.js';
+
+/**
+ * The tool list is a public API: renaming an entry breaks every client that
+ * refers to it by name, so the convention is worth pinning rather than
+ * rediscovering one tool at a time.
+ */
+describe('allTools', () => {
+  const toolNames = allTools(
+    {} as Backlog,
+    createDescriptionHelper()
+  ).toolsets.flatMap((toolset) => toolset.tools.map((tool) => tool.name));
+
+  it('names every tool in snake_case', () => {
+    const offenders = toolNames.filter(
+      (name) => !/^[a-z][a-z0-9]*(_[a-z0-9]+)*$/.test(name)
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('gives every tool a distinct name', () => {
+    const duplicates = toolNames.filter(
+      (name, index) => toolNames.indexOf(name) !== index
+    );
+
+    expect(duplicates).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

`addDocument` is the only tool in the list published under a camelCase name. Every other one is snake_case — including the four other document tools it sits next to:

```
get_documents, get_document_tree, get_document, addDocument
```

Its own description keys are already `TOOL_ADD_DOCUMENT_*`, so the inconsistency is limited to the one string clients actually see.

## Changes

- `name: 'addDocument'` → `name: 'add_document'`
- New `src/tools/tools.test.ts` pinning the convention over `allTools`: every tool name matches `^[a-z][a-z0-9]*(_[a-z0-9]+)*$`, and no two tools share a name. Verified that it fails before the rename:

  ```
  AssertionError: expected [ 'addDocument' ] to deeply equal []
  ```

The source file keeps its `addDocument.ts` name — file naming is camelCase throughout `src/tools`, so renaming it would break *that* convention instead.

## Compatibility — please decide

Tool names are a public API. Clients discover them at runtime, so most setups pick the new name up automatically, but anything that pins the old string breaks:

- allow lists / permission rules that name the tool (e.g. `mcp__backlog__addDocument` in Claude Code settings)
- prompts or agent configs that reference it directly
- `TOOL_ADD_DOCUMENT_DESCRIPTION` overrides are unaffected — the keys do not change

If you would rather not break those, I am happy to instead register `addDocument` as a deprecated alias for a release or two. I did not do that here because it puts a second copy of the schema in every `tools/list` response, which cuts against the recent work to keep that payload small — but it is a small change either way, so tell me which you prefer.

## Checks

`pnpm run lint`, `pnpm run format`, `pnpm test` (91 files / 485 tests, including the 2 new ones) and `pnpm run build` all pass.