### PR TITLE
fix: keep /health reachable under the Host allow list

### DIFF
--- a/src/httpMcpServer.test.ts
+++ b/src/httpMcpServer.test.ts
@@ -37,14 +37,19 @@ type RawResponse = { status: number; body: string };
  */
 const send = (
   port: number,
-  options: { method?: string; headers?: Record<string, string>; body?: string }
+  options: {
+    method?: string;
+    path?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  }
 ): Promise<RawResponse> =>
   new Promise((resolve, reject) => {
     const req = httpRequest(
       {
         host: '127.0.0.1',
         port,
-        path: '/mcp',
+        path: options.path ?? '/mcp',
         method: options.method ?? 'POST',
         headers: {
           'content-type': 'application/json',
@@ -164,6 +169,44 @@ describe('runHttpMcpServer', () => {
       const port = await start({ allowedHosts: ['mcp.example.com'] });
       const res = await send(port, {
         headers: { host: '127.0.0.1', 'mcp-method': 'tools/list' },
+        body: modernToolsList,
+      });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('/health', () => {
+    // A load balancer health check addresses the target directly, so its `Host`
+    // is the target's own address and can never be on the allow list. Guarding
+    // /health would make the check permanently unhealthy.
+    it('answers a Host outside the allow list', async () => {
+      const port = await start({ allowedHosts: ['mcp.example.com'] });
+      const res = await send(port, {
+        method: 'GET',
+        path: '/health',
+        headers: { host: '10.0.0.1:3333' },
+      });
+
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body).status).toBe('healthy');
+    });
+
+    it('answers a foreign Host on a loopback bind', async () => {
+      const port = await start();
+      const res = await send(port, {
+        method: 'GET',
+        path: '/health',
+        headers: { host: 'evil.example.com' },
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('does not exempt /mcp', async () => {
+      const port = await start({ allowedHosts: ['mcp.example.com'] });
+      const res = await send(port, {
+        headers: { host: '10.0.0.1:3333', 'mcp-method': 'tools/list' },
         body: modernToolsList,
       });
 

--- a/src/httpMcpServer.ts
+++ b/src/httpMcpServer.ts
@@ -66,6 +66,17 @@ export const runHttpMcpServer = async (
   const isLocalhostBind = LOCALHOST_BINDS.includes(host);
   const oauthEnabled = !!(oauthConfig && tokenStore);
 
+  // Registered before the Host and Origin guards so that it stays reachable
+  // under an allow list. A load balancer health check addresses the target
+  // directly and puts its address in `Host` — AWS ALB gives no way to override
+  // it — so a guarded `/health` can only ever answer 403, leaving an operator
+  // to choose between dropping the allow list and treating 403 as healthy.
+  // Exempting it costs nothing: the response is constant and reaches no state,
+  // so there is nothing here for a rebinding page to reach either.
+  app.get('/health', (c) =>
+    c.json({ status: 'healthy', timestamp: new Date().toISOString(), version })
+  );
+
   // DNS rebinding protection. `Host` is the actual defense: a rebinding page
   // reaches us carrying its own hostname, which the allow list rejects.
   if (allowedHosts?.length) {
@@ -85,10 +96,6 @@ export const runHttpMcpServer = async (
   } else if (isLocalhostBind && !allowedHosts?.length) {
     app.use('*', localhostOriginValidation());
   }
-
-  app.get('/health', (c) =>
-    c.json({ status: 'healthy', timestamp: new Date().toISOString(), version })
-  );
 
   if (oauthEnabled) {
     const { createOAuthRoutes } = await import('./auth/oauthRoutes.js');


### PR DESCRIPTION
Implements option (1) from #214: register `/health` before the Host and Origin guards.

## Why

`runHttpMcpServer` installed the DNS-rebinding guard with `app.use('*', ...)` before registering `/health`, so setting `MCP_HTTP_ALLOWED_HOSTS` put the health endpoint behind the allow list. A load balancer health check addresses the target directly and puts the target's own address in `Host`; AWS ALB offers no way to override it. The check could therefore only ever receive `403`:

```
GET /health   Host: <public hostname>   -> 200 {"status":"healthy",...}
GET /health   Host: 10.0.0.1:3333       -> 403 {"error":{"code":-32000,"message":"Invalid Host: 10.0.0.1"}}
```

That leaves an operator choosing between dropping the allow list — giving up the protection the flag exists for — and configuring the load balancer to accept `403` as healthy, which also makes a genuine `403` from any other cause read as healthy.

## What changed

`/health` is registered before both guards. Exempting it costs nothing on the axis they defend: the response is a constant JSON body and reaches no state, so there is nothing behind it for a rebinding page to reach. `/mcp`, the OAuth routes and everything else stay guarded.

## Tests

Three cases added to `src/httpMcpServer.test.ts`, alongside the existing rebinding coverage:

- `/health` answers `200` for a `Host` outside the allow list — the load balancer case
- `/health` answers `200` for a foreign `Host` on a loopback bind
- `/mcp` still answers `403` for the same `Host`, so the exemption is scoped to `/health`

The `send` helper gained an optional `path` (defaulting to `/mcp`) so a `GET /health` can be driven through the same raw `node:http` request the rebinding tests use — `fetch` treats `Host` as a forbidden header.

## Verified

`pnpm test` (91 files, 488 tests), `pnpm lint`, `pnpm format` and `pnpm build` all pass on Node 24.14.1 / pnpm 10.34.4.
