### PR TITLE
feat: let an external TokenStore replace the in-memory OAuth state

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ BACKLOG_DOMAIN=your-domain.backlog.com
 # BACKLOG_OAUTH_CLIENT_ID=your-oauth-client-id
 # BACKLOG_OAUTH_CLIENT_SECRET=your-oauth-client-secret
 # MCP_SERVER_BASE_URL=https://your-mcp-server.example.com
+# Optional: replace the in-memory OAuth token store, which is lost on restart
+# and not shared between instances. Names a module whose default export builds
+# a TokenStore. See the OAuth section of the README.
+# MCP_TOKEN_STORE_MODULE=./token-store.mjs
 
 # Logging (optional). fatal | error | warn | info | debug | trace | silent.
 # Defaults to `error` in production (including when NODE_ENV is unset), `debug` otherwise.

--- a/README.ja.md
+++ b/README.ja.md
@@ -159,6 +159,7 @@ MCPサーバーをネットワーク経由で公開する場合、OAuth 2.0認�
 | `BACKLOG_OAUTH_CLIENT_ID`     | Backlogアプリケーションの OAuth Client ID             |
 | `BACKLOG_OAUTH_CLIENT_SECRET` | Backlogアプリケーションの OAuth Client Secret         |
 | `MCP_SERVER_BASE_URL`         | MCPサーバーの公開URL（例：`https://mcp.example.com`） |
+| `MCP_TOKEN_STORE_MODULE`      | 任意。外部トークンストアを供給するモジュール（後述） |
 
 > **注意:** OAuth有効時は `BACKLOG_API_KEY` は**不要**です。各ユーザーが自分のBacklogアカウントで認証します。
 
@@ -196,10 +197,51 @@ MCP認可仕様に対応するMCPクライアントは、これらのエンド�
 宣言なしでリモートの `https:` URI とループバック URI を混在させた登録は
 `invalid_client_metadata` で拒否されます。
 
+#### トークンの保存先
+
+クライアント登録とこのサーバーが発行するトークンは、既定ではメモリ内に保持されます。
+デスクトップ用途や単一インスタンスの構成にはこれが適切な既定値ですが、それ以上の規模では
+2 つの帰結があります。再起動のたびに全ユーザーの再認可が必要になること、そして 1 台目が
+開始したセッションを 2 台目が引き継げないことです。ロードバランサのスティッキーセッションでは
+解決しません。`/authorize` と `/callback` はユーザーのブラウザから、`/token` と `/mcp` は
+MCP クライアントから届くため、どのような Cookie でも同一プロセスに寄せられないからです。
+
+`--token-store-module`（または `MCP_TOKEN_STORE_MODULE`）は、既定のストアを置き換える
+モジュールを指定します。値はパスでもパッケージ名でもよく、default export の factory は
+`async` でも構いません。ストアの各メソッドは値と Promise のどちらを返してもよいため、
+Redis / DynamoDB / Durable Object を裏に持つストアも、インメモリ実装と同じ契約を満たせます。
+
+```js
+// token-store.mjs
+export default async () => ({
+  async storePendingAuth(state, pending) { /* ... */ },
+  async consumePendingAuth(state) { /* ... */ },
+  // ...残りの TokenStore のメソッド
+});
+```
+
+```bash
+backlog-mcp-server --transport http --token-store-module ./token-store.mjs
+```
+
+TypeScript で実装する場合、`TokenStore` 型をパッケージから import できます。
+
+```ts
+import type { TokenStore, TokenStoreFactory } from 'backlog-mcp-server';
+```
+
+型では表現できない約束が 2 つあります。`consumePendingAuth` / `consumeAuthCode` /
+`consumeMcpRefreshToken` は取得と削除をアトミックに行う必要があります（これらは設計上
+1 回限りで、認可コードが 2 インスタンスに対して再生されるとトークンが二重に発行される
+ため）。また、期限切れのエントリを返してはいけません。各エントリは自身の期限を保持して
+いるので、ネイティブの TTL に任せても構いません。
+
+指定したモジュールはサーバープロセスが import して実行します。そのため、モジュールは
+コマンドラインと同じ信頼レベルで扱われます。
+
 > **制約事項:**
 >
 > - OAuthモードは現在、単一のBacklog組織のみをサポートしています。複数組織設定との併用はできません。
-> - クライアント登録やトークンはメモリ内に保持されるため、サーバー再起動時に失われます。
 
 ## ツール設定
 
@@ -546,6 +588,7 @@ pnpm test
 
 - `--export-descriptions`: ツール一覧の構築時に解決される説明キーと値をエクスポート。旧名は `--export-translations` で、非推奨エイリアスとして当面動作しますが、将来のリリースで削除されます
 - `--optimize-response`: 各ツールに、返す結果フィールドを選ぶ `fields` パラメータを追加する
+- `--token-store-module`: OAuth トークンストアを構築するモジュールのパスまたはパッケージ名。既定はインメモリのストアで、再起動で失われ、インスタンス間で共有されません。
 - `--max-tokens=NUMBER`: レスポンスの最大トークン制限を設定
 - `--prefix=STRING`: すべてのツール名に付加するオプションの文字列プレフィックス（デフォルト：""）
 - `--enable-toolsets <toolsets...>`: 有効にするツールセットを指定します（カンマ区切りまたは複数の引数）。デフォルトは "all" です。

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The server implements the [MCP Third-Party Authorization Flow](https://modelcont
 | `BACKLOG_OAUTH_CLIENT_ID`     | OAuth Client ID from your Backlog application                   |
 | `BACKLOG_OAUTH_CLIENT_SECRET` | OAuth Client Secret from your Backlog application               |
 | `MCP_SERVER_BASE_URL`         | Public URL of your MCP server (e.g., `https://mcp.example.com`) |
+| `MCP_TOKEN_STORE_MODULE`      | Optional. Module supplying an external token store (see below)  |
 
 > **Note:** `BACKLOG_API_KEY` is **not required** when OAuth is enabled — each user authenticates with their own Backlog account.
 
@@ -223,10 +224,54 @@ absent, from one whose redirect URIs are _all_ loopback. A client declaring
 `"application_type": "web"`, or mixing a remote `https:` URI with a loopback one
 without declaring itself, is rejected with `invalid_client_metadata`.
 
+#### Token storage
+
+Client registrations and the tokens this server issues are held in memory by
+default. That is the right default for a desktop or single-instance server, and
+it has two consequences for anything larger: every restart costs every user a
+re-authorization, and a second instance cannot serve a session the first one
+started. Load-balancer stickiness does not help — `/authorize` and `/callback`
+arrive from the user's browser while `/token` and `/mcp` arrive from the MCP
+client, so no cookie can land them on the same process.
+
+`--token-store-module` (or `MCP_TOKEN_STORE_MODULE`) names a module whose
+default export builds a replacement. The module may be a path or a package name,
+and its factory may be `async`; every method of the store may return a value or
+a Promise, so a store backed by Redis, DynamoDB or a Durable Object satisfies
+the same contract as the in-memory one:
+
+```js
+// token-store.mjs
+export default async () => ({
+  async storePendingAuth(state, pending) { /* ... */ },
+  async consumePendingAuth(state) { /* ... */ },
+  // ...and the rest of TokenStore
+});
+```
+
+```bash
+backlog-mcp-server --transport http --token-store-module ./token-store.mjs
+```
+
+The `TokenStore` type is exported from the package for implementations written
+in TypeScript:
+
+```ts
+import type { TokenStore, TokenStoreFactory } from 'backlog-mcp-server';
+```
+
+Two obligations the type cannot express. `consumePendingAuth`, `consumeAuthCode`
+and `consumeMcpRefreshToken` must read and delete atomically — they are
+single-use by design, and an authorization code replayed against two instances
+would otherwise mint two token pairs. And an expired entry must never be served;
+every entry carries its own deadline, so a native TTL may enforce it instead.
+
+The module is imported and executed by the server process, so it is as trusted
+as the command line it was named on.
+
 > **Limitations:**
 >
 > - OAuth mode currently supports a single Backlog organization. It is not compatible with the multi-organization configuration.
-> - Client registrations and tokens are stored in memory and will be lost on server restart.
 
 ## Tool Configuration
 
@@ -666,6 +711,7 @@ The server supports several command line options:
 - `--http-json-response`: Prefer JSON responses over SSE. Applies to `2026-07-28` clients only; the backward-compatible `2025-11-25` path is served with the SDK's default response shaping.
 - `--http-allowed-hosts`: Comma-separated allowed `Host` hostnames (port-agnostic). Needed when binding to all interfaces, or on a loopback bind behind a reverse proxy.
 - `--http-allowed-origins`: Comma-separated allowed `Origin` hostnames for browser-based clients. Defaults to the localhost set on a bare loopback bind, and to no `Origin` check otherwise.
+- `--token-store-module`: Path or package name of a module whose default export builds the OAuth token store. Defaults to an in-memory store, which is lost on restart and not shared between instances.
 - `--export-descriptions`: Export the description keys and values resolved when building the tool list. Was named `--export-translations`; that spelling still works as a deprecated alias and will be removed in a future release
 - `--optimize-response`: Add a `fields` parameter to each tool for selecting which result fields to return
 - `--max-tokens=NUMBER`: Set maximum token limit for responses

--- a/src/auth/bearerAuthMiddleware.test.ts
+++ b/src/auth/bearerAuthMiddleware.test.ts
@@ -179,6 +179,37 @@ describe('createBearerAuthMiddleware', () => {
       expect(body.error_description).toContain('Unknown or expired');
     });
 
+    // `reportBacklogAuthError` invokes the revocation synchronously from inside
+    // the tool handler, so an asynchronous store's promise has nowhere to be
+    // awaited at that point. Left unawaited it would settle after the response,
+    // and the next request would still find the token the middleware believes
+    // it revoked.
+    it('finishes an asynchronous revocation before answering', async () => {
+      const asyncStore = {
+        ...store,
+        revokeMcpToken: async (mcpToken: string) => {
+          // A macrotask, so the revocation cannot settle on the microtask
+          // queue the response already drains: only an explicit await keeps
+          // the middleware from answering first.
+          await new Promise((r) => setTimeout(r, 0));
+          store.revokeMcpToken(mcpToken);
+        },
+      };
+      const asyncFailing = new Hono();
+      asyncFailing.use(
+        '/mcp',
+        createBearerAuthMiddleware(asyncStore, config, '/mcp')
+      );
+      asyncFailing.post('/mcp', (c) => {
+        reportBacklogAuthError();
+        return c.json({ ok: true });
+      });
+
+      await call(asyncFailing);
+
+      expect(store.getMcpToken('mcp-token-live')).toBeUndefined();
+    });
+
     it('leaves a request that reported nothing untouched', async () => {
       const res = await call(app);
 

--- a/src/auth/bearerAuthMiddleware.ts
+++ b/src/auth/bearerAuthMiddleware.ts
@@ -57,12 +57,12 @@ export function createBearerAuthMiddleware(
       );
     }
 
-    const tokenEntry = store.getMcpToken(mcpToken);
+    const tokenEntry = await store.getMcpToken(mcpToken);
     if (!tokenEntry) {
       return unauthorized('Unknown or expired token');
     }
 
-    let authInfo = store.getCachedVerification(mcpToken);
+    let authInfo = await store.getCachedVerification(mcpToken);
 
     if (!authInfo) {
       try {
@@ -76,7 +76,7 @@ export function createBearerAuthMiddleware(
           scopes: [],
           expiresAt: Math.floor(Date.now() / 1000) + CACHE_TTL_MS / 1000,
         } satisfies AuthInfo;
-        store.cacheVerification(mcpToken, authInfo, CACHE_TTL_MS);
+        await store.cacheVerification(mcpToken, authInfo, CACHE_TTL_MS);
       } catch (err) {
         logger.warn({ err }, 'Bearer token verification failed');
         return unauthorized('Token verification failed');
@@ -93,12 +93,29 @@ export function createBearerAuthMiddleware(
     // Invalidation happens the moment the failure is reported rather than after
     // `next()` settles, because a response that upgraded to SSE resolves before
     // its handler has run.
+    //
+    // `reportBacklogAuthError` calls this synchronously from inside a tool
+    // handler, so an asynchronous store cannot be awaited here. The promise is
+    // captured instead and awaited once the request is decided: starting the
+    // revocation at the moment of detection is what the timing above is about,
+    // and finishing it before the response leaves is what keeps a rejected
+    // token from surviving into the next request. Catching is not optional —
+    // an unhandled rejection from a network-backed store would take the process
+    // down through the handler in `src/index.ts`.
+    let revocation: Promise<void> | undefined;
     const onAuthError = () => {
       logger.warn(
         { clientId: tokenEntry.clientId },
         'Backlog rejected the stored access token; revoking the MCP token'
       );
-      store.revokeMcpToken(mcpToken);
+      revocation = Promise.resolve(store.revokeMcpToken(mcpToken)).catch(
+        (err: unknown) => {
+          logger.error(
+            { err, clientId: tokenEntry.clientId },
+            'Failed to revoke the MCP token after a Backlog authentication error'
+          );
+        }
+      );
     };
 
     await runWithAccessToken(
@@ -113,5 +130,7 @@ export function createBearerAuthMiddleware(
       },
       onAuthError
     );
+
+    await revocation;
   };
 }

--- a/src/auth/loadTokenStoreModule.test.ts
+++ b/src/auth/loadTokenStoreModule.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 Nulab inc.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadTokenStoreModule } from './loadTokenStoreModule.js';
+
+const METHODS = [
+  'storePendingAuth',
+  'consumePendingAuth',
+  'storeAuthCode',
+  'consumeAuthCode',
+  'getClient',
+  'registerClient',
+  'getCachedVerification',
+  'cacheVerification',
+  'storeMcpToken',
+  'getMcpToken',
+  'revokeMcpToken',
+  'storeMcpRefreshToken',
+  'consumeMcpRefreshToken',
+  'cleanup',
+];
+
+/**
+ * Written to a temp directory and imported by absolute path, which is the case
+ * that matters: a store lives outside this package, so it cannot be resolved
+ * relative to the loader.
+ */
+const writeModule = (source: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'token-store-'));
+  const file = join(dir, 'store.mjs');
+  writeFileSync(file, source);
+  return file;
+};
+
+const storeSource = (omit: string[] = []): string => {
+  const methods = METHODS.filter((m) => !omit.includes(m))
+    .map((m) => `  ${m}: async () => undefined,`)
+    .join('\n');
+  return `export default async () => ({\n${methods}\n});\n`;
+};
+
+describe('loadTokenStoreModule', () => {
+  it('builds a store from a module default-exporting an async factory', async () => {
+    const store = await loadTokenStoreModule(writeModule(storeSource()));
+
+    for (const method of METHODS) {
+      expect(typeof (store as Record<string, unknown>)[method]).toBe(
+        'function'
+      );
+    }
+  });
+
+  it('rejects a module without a default export', async () => {
+    const file = writeModule('export const createStore = () => ({});\n');
+
+    await expect(loadTokenStoreModule(file)).rejects.toThrow(
+      /must default-export a function/
+    );
+  });
+
+  it('rejects a factory that does not return an object', async () => {
+    const file = writeModule('export default () => 42;\n');
+
+    await expect(loadTokenStoreModule(file)).rejects.toThrow(
+      /returned number instead of a TokenStore/
+    );
+  });
+
+  it('names the methods an incomplete store is missing', async () => {
+    const file = writeModule(storeSource(['getMcpToken', 'cleanup']));
+
+    await expect(loadTokenStoreModule(file)).rejects.toThrow(
+      /missing required method\(s\): getMcpToken, cleanup/
+    );
+  });
+
+  it('reports an unresolvable specifier', async () => {
+    await expect(
+      loadTokenStoreModule('./definitely-not-a-real-store.mjs')
+    ).rejects.toThrow();
+  });
+});

--- a/src/auth/loadTokenStoreModule.ts
+++ b/src/auth/loadTokenStoreModule.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 Nulab inc.
+// Licensed under the MIT License.
+
+import { isAbsolute, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { TokenStore, TokenStoreFactory } from './tokenStore.js';
+
+/**
+ * Every method `TokenStore` declares. Checked at load time so a store missing
+ * one fails at startup with the name of what is missing, rather than midway
+ * through an authorization with a `TypeError` from inside a route handler.
+ */
+const REQUIRED_METHODS = [
+  'storePendingAuth',
+  'consumePendingAuth',
+  'storeAuthCode',
+  'consumeAuthCode',
+  'getClient',
+  'registerClient',
+  'getCachedVerification',
+  'cacheVerification',
+  'storeMcpToken',
+  'getMcpToken',
+  'revokeMcpToken',
+  'storeMcpRefreshToken',
+  'consumeMcpRefreshToken',
+  'cleanup',
+] as const satisfies readonly (keyof TokenStore)[];
+
+/**
+ * A relative or absolute path is resolved against the working directory, not
+ * against this file: `import('./store.js')` from here would look inside the
+ * installed package, which is never what the operator meant. A bare specifier
+ * is passed through so a store published to npm resolves the usual way.
+ */
+const toImportSpecifier = (specifier: string): string =>
+  specifier.startsWith('.') || isAbsolute(specifier)
+    ? pathToFileURL(resolve(specifier)).href
+    : specifier;
+
+const missingMethods = (value: object): string[] =>
+  REQUIRED_METHODS.filter(
+    (method) => typeof (value as Record<string, unknown>)[method] !== 'function'
+  );
+
+/**
+ * Loads the module named by `--token-store-module` and calls its default export
+ * to build a store.
+ *
+ * The module is arbitrary code chosen by whoever starts the server, and runs
+ * with the server's privileges — the same trust level as the command line it
+ * came from.
+ */
+export async function loadTokenStoreModule(
+  specifier: string
+): Promise<TokenStore> {
+  const imported: unknown = await import(toImportSpecifier(specifier));
+
+  const factory = (imported as { default?: unknown }).default;
+  if (typeof factory !== 'function') {
+    throw new Error(
+      `Token store module "${specifier}" must default-export a function returning a TokenStore.`
+    );
+  }
+
+  const store: unknown = await (factory as TokenStoreFactory)();
+  if (typeof store !== 'object' || store === null) {
+    throw new Error(
+      `Token store module "${specifier}" returned ${store === null ? 'null' : typeof store} instead of a TokenStore.`
+    );
+  }
+
+  const missing = missingMethods(store);
+  if (missing.length > 0) {
+    throw new Error(
+      `Token store from "${specifier}" is missing required method(s): ${missing.join(', ')}.`
+    );
+  }
+
+  return store as TokenStore;
+}

--- a/src/auth/oauthRoutes.test.ts
+++ b/src/auth/oauthRoutes.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createHash } from 'node:crypto';
 import { createOAuthRoutes } from './oauthRoutes.js';
-import { createTokenStore, type TokenStore } from './tokenStore.js';
+import { createTokenStore } from './tokenStore.js';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 
 vi.mock('./backlogOAuthClient.js', () => ({
@@ -34,7 +34,7 @@ const config: BacklogOAuthConfig = {
 };
 
 describe('createOAuthRoutes', () => {
-  let store: TokenStore;
+  let store: ReturnType<typeof createTokenStore>;
   let app: ReturnType<typeof createOAuthRoutes>;
 
   beforeEach(() => {

--- a/src/auth/oauthRoutes.ts
+++ b/src/auth/oauthRoutes.ts
@@ -228,7 +228,7 @@ export function createOAuthRoutes(
       response_types: ['code'],
     };
 
-    if (!store.registerClient(client)) {
+    if (!(await store.registerClient(client))) {
       return c.json(
         oauthError(
           'server_error',
@@ -262,7 +262,7 @@ export function createOAuthRoutes(
       return c.json(oauthError('invalid_request', 'Missing client_id'), 400);
     }
 
-    const client = store.getClient(clientId);
+    const client = await store.getClient(clientId);
     if (!client) {
       return c.json(oauthError('invalid_client', 'Unknown client_id'), 400);
     }
@@ -328,7 +328,7 @@ export function createOAuthRoutes(
 
     // Store pending authorization and redirect to Backlog
     const backlogState = randomUUID();
-    store.storePendingAuth(backlogState, {
+    await store.storePendingAuth(backlogState, {
       mcpClientId: clientId,
       codeChallenge,
       redirectUri: effectiveRedirectUri,
@@ -359,7 +359,7 @@ export function createOAuthRoutes(
     }
 
     if (backlogError || !backlogCode) {
-      const pending = store.consumePendingAuth(backlogState);
+      const pending = await store.consumePendingAuth(backlogState);
       if (!pending) {
         return c.text(
           'Unknown or expired authorization state. Please start the authorization flow again.',
@@ -378,7 +378,7 @@ export function createOAuthRoutes(
       return c.redirect(errorUrl.href, 302);
     }
 
-    const pending = store.consumePendingAuth(backlogState);
+    const pending = await store.consumePendingAuth(backlogState);
     if (!pending) {
       return c.text(
         'Unknown or expired authorization state. Please start the authorization flow again.',
@@ -407,7 +407,7 @@ export function createOAuthRoutes(
     }
 
     const mcpCode = randomUUID();
-    store.storeAuthCode(mcpCode, {
+    await store.storeAuthCode(mcpCode, {
       mcpClientId: pending.mcpClientId,
       backlogTokens,
       // Resolved here, against the response just received, rather than at
@@ -440,7 +440,7 @@ export function createOAuthRoutes(
       return c.json(oauthError('invalid_request', 'Missing client_id'), 400);
     }
 
-    const client = store.getClient(clientId);
+    const client = await store.getClient(clientId);
     if (!client) {
       return c.json(oauthError('invalid_client', 'Unknown client_id'), 401);
     }
@@ -459,7 +459,7 @@ export function createOAuthRoutes(
         return c.json(oauthError('invalid_request', 'Missing code'), 400);
       }
 
-      const entry = store.consumeAuthCode(code);
+      const entry = await store.consumeAuthCode(code);
       if (!entry) {
         return c.json(
           oauthError('invalid_grant', 'Invalid or expired authorization code'),
@@ -501,12 +501,12 @@ export function createOAuthRoutes(
       const mcpAccessToken = randomBytes(32).toString('hex');
       const mcpRefreshToken = randomBytes(32).toString('hex');
 
-      store.storeMcpToken(mcpAccessToken, {
+      await store.storeMcpToken(mcpAccessToken, {
         backlogAccessToken: entry.backlogTokens.access_token,
         clientId,
         expiresAt: entry.backlogAccessTokenExpiresAt,
       });
-      store.storeMcpRefreshToken(mcpRefreshToken, {
+      await store.storeMcpRefreshToken(mcpRefreshToken, {
         backlogRefreshToken: entry.backlogTokens.refresh_token,
         clientId,
         expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
@@ -532,7 +532,7 @@ export function createOAuthRoutes(
         );
       }
 
-      const refreshEntry = store.consumeMcpRefreshToken(refreshToken);
+      const refreshEntry = await store.consumeMcpRefreshToken(refreshToken);
       if (!refreshEntry) {
         return c.json(
           oauthError('invalid_grant', 'Invalid or expired refresh token'),
@@ -559,12 +559,12 @@ export function createOAuthRoutes(
         const mcpAccessToken = randomBytes(32).toString('hex');
         const mcpRefreshToken = randomBytes(32).toString('hex');
 
-        store.storeMcpToken(mcpAccessToken, {
+        await store.storeMcpToken(mcpAccessToken, {
           backlogAccessToken: tokens.access_token,
           clientId,
           expiresAt: Date.now() + tokens.expires_in * 1000,
         });
-        store.storeMcpRefreshToken(mcpRefreshToken, {
+        await store.storeMcpRefreshToken(mcpRefreshToken, {
           backlogRefreshToken: tokens.refresh_token,
           clientId,
           expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
@@ -578,7 +578,7 @@ export function createOAuthRoutes(
         });
       } catch (err) {
         logger.error({ err }, 'Failed to refresh Backlog token');
-        store.storeMcpRefreshToken(refreshToken, refreshEntry);
+        await store.storeMcpRefreshToken(refreshToken, refreshEntry);
         return c.json(
           oauthError('server_error', 'Failed to refresh upstream token'),
           503

--- a/src/auth/tokenStore.test.ts
+++ b/src/auth/tokenStore.test.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createTokenStore, type TokenStore } from './tokenStore.js';
+import { createTokenStore } from './tokenStore.js';
 
 describe('createTokenStore', () => {
-  let store: TokenStore;
+  let store: ReturnType<typeof createTokenStore>;
 
   beforeEach(() => {
     store = createTokenStore();

--- a/src/auth/tokenStore.ts
+++ b/src/auth/tokenStore.ts
@@ -22,7 +22,7 @@ export type OAuthClientInfo = {
   response_types?: string[];
 };
 
-type PendingAuthorization = {
+export type PendingAuthorization = {
   mcpClientId: string;
   codeChallenge: string;
   redirectUri: string;
@@ -32,7 +32,7 @@ type PendingAuthorization = {
   createdAt: number;
 };
 
-type AuthCodeEntry = {
+export type AuthCodeEntry = {
   mcpClientId: string;
   backlogTokens: BacklogTokenData;
   /**
@@ -63,7 +63,7 @@ export type McpTokenEntry = {
   expiresAt: number;
 };
 
-type McpRefreshEntry = {
+export type McpRefreshEntry = {
   backlogRefreshToken: string;
   clientId: string;
   expiresAt: number;
@@ -73,7 +73,74 @@ const PENDING_AUTH_TTL_MS = 10 * 60 * 1000;
 const CLIENT_TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
 const MAX_CLIENTS = 1000;
 
-export type TokenStore = ReturnType<typeof createTokenStore>;
+/**
+ * A value a store may return directly or after a round trip.
+ *
+ * The default store is in-memory and answers synchronously; anything backed by
+ * a network — Redis, DynamoDB, a Durable Object — cannot. Widening the contract
+ * rather than the implementation keeps the default free of a Promise it has no
+ * use for, while letting an external one satisfy the same type.
+ */
+type Awaitable<T> = T | Promise<T>;
+
+/**
+ * The OAuth state this server owns: dynamic client registrations, in-flight
+ * authorizations, and the tokens it issues. The MCP SDK ships the
+ * resource-server side, so none of this is state it can hold on our behalf.
+ *
+ * Two obligations an implementation must honour, neither of which the type can
+ * express:
+ *
+ * - `consumePendingAuth`, `consumeAuthCode` and `consumeMcpRefreshToken` must
+ *   read and delete atomically. They are single-use by design — an
+ *   authorization code replayed against two instances would mint two token
+ *   pairs — so a backing store shared across processes needs a delete that
+ *   reports whether it won, not a read followed by a delete.
+ * - Expiry is the store's to enforce. Every entry carries its own deadline and
+ *   the accessors above drop what has passed, so an implementation may lean on
+ *   a native TTL instead, but it may not serve an expired entry.
+ */
+export type TokenStore = {
+  storePendingAuth(
+    backlogState: string,
+    pending: PendingAuthorization
+  ): Awaitable<void>;
+  consumePendingAuth(
+    backlogState: string
+  ): Awaitable<PendingAuthorization | undefined>;
+  storeAuthCode(code: string, entry: AuthCodeEntry): Awaitable<void>;
+  consumeAuthCode(code: string): Awaitable<AuthCodeEntry | undefined>;
+  getClient(clientId: string): Awaitable<OAuthClientInfo | undefined>;
+  registerClient(client: OAuthClientInfo): Awaitable<boolean>;
+  getCachedVerification(token: string): Awaitable<AuthInfo | undefined>;
+  cacheVerification(
+    token: string,
+    authInfo: AuthInfo,
+    ttlMs: number
+  ): Awaitable<void>;
+  storeMcpToken(mcpToken: string, entry: McpTokenEntry): Awaitable<void>;
+  getMcpToken(mcpToken: string): Awaitable<McpTokenEntry | undefined>;
+  /**
+   * Drops an MCP access token and its cached verification. Called when Backlog
+   * rejects the stored credential, from a synchronous callback deep inside a
+   * tool handler — the caller cannot await it there, so an implementation must
+   * not depend on the request still being in flight when it settles.
+   */
+  revokeMcpToken(mcpToken: string): Awaitable<void>;
+  storeMcpRefreshToken(
+    mcpRefreshToken: string,
+    entry: McpRefreshEntry
+  ): Awaitable<void>;
+  consumeMcpRefreshToken(
+    mcpRefreshToken: string
+  ): Awaitable<McpRefreshEntry | undefined>;
+  cleanup(): Awaitable<void>;
+};
+
+/**
+ * What a module named by `--token-store-module` must export as its default.
+ */
+export type TokenStoreFactory = () => Awaitable<TokenStore>;
 
 export function createTokenStore() {
   const pendingAuthorizations = new Map<string, PendingAuthorization>();
@@ -220,5 +287,5 @@ export function createTokenStore() {
           clients.delete(key);
       }
     },
-  };
+  } satisfies TokenStore;
 }

--- a/src/httpMcpServer.oauth.test.ts
+++ b/src/httpMcpServer.oauth.test.ts
@@ -1,0 +1,388 @@
+// Copyright (c) 2025 Nulab inc.
+// Licensed under the MIT License.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createHash, randomBytes } from 'node:crypto';
+import type { AddressInfo } from 'node:net';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/server';
+import { runHttpMcpServer } from './httpMcpServer.js';
+import type { BacklogOAuthConfig } from './auth/backlogOAuthConfig.js';
+import type {
+  AuthCodeEntry,
+  McpRefreshEntry,
+  McpTokenEntry,
+  OAuthClientInfo,
+  PendingAuthorization,
+  TokenStore,
+} from './auth/tokenStore.js';
+import {
+  wrapServerWithToolRegistry,
+  type BacklogMCPServer,
+} from './utils/wrapServerWithToolRegistry.js';
+
+vi.mock('./auth/backlogOAuthClient.js', () => ({
+  buildBacklogAuthorizationUrl: vi.fn(
+    (_config: unknown, _redirect: unknown, state: string) =>
+      `https://example.backlog.com/OAuth2AccessRequest.action?state=${state}`
+  ),
+  exchangeBacklogCode: vi.fn().mockResolvedValue({
+    access_token: 'bl-access',
+    token_type: 'bearer',
+    expires_in: 3600,
+    refresh_token: 'bl-refresh',
+  }),
+  refreshBacklogToken: vi.fn().mockResolvedValue({
+    access_token: 'bl-new-access',
+    token_type: 'bearer',
+    expires_in: 3600,
+    refresh_token: 'bl-new-refresh',
+  }),
+  verifyBacklogToken: vi.fn().mockResolvedValue({ id: 42, name: 'tester' }),
+}));
+
+const MODERN_ENVELOPE = {
+  'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+  'io.modelcontextprotocol/clientCapabilities': {},
+};
+
+const oauthConfig: BacklogOAuthConfig = {
+  clientId: 'bl-client-id',
+  clientSecret: 'bl-client-secret',
+  backlogDomain: 'example.backlog.com',
+  serverBaseUrl: 'https://mcp.example.com',
+};
+
+const createServer = (): BacklogMCPServer => {
+  const server = wrapServerWithToolRegistry(
+    new McpServer({ name: 'backlog-test', version: '0.0.0' })
+  );
+  server.registerOnce('ping', 'test tool', z.object({}), () => ({
+    content: [{ type: 'text' as const, text: 'pong' }],
+  }));
+  return server;
+};
+
+/**
+ * A `TokenStore` whose every method is `async`, standing in for anything that
+ * has to cross a network — Redis, DynamoDB, a Durable Object.
+ *
+ * The point is not the Map behind it. It is that the OAuth flow completes
+ * against a store that answers with Promises only, which is what a synchronous
+ * `TokenStore` type made impossible to express and what an external
+ * implementation would have to be.
+ */
+const createAsyncTokenStore = (): TokenStore & { calls: string[] } => {
+  const pendingAuthorizations = new Map<string, PendingAuthorization>();
+  const authorizationCodes = new Map<string, AuthCodeEntry>();
+  const clients = new Map<string, OAuthClientInfo>();
+  const verificationCache = new Map<
+    string,
+    { authInfo: unknown; expiresAt: number }
+  >();
+  const mcpAccessTokens = new Map<string, McpTokenEntry>();
+  const mcpRefreshTokens = new Map<string, McpRefreshEntry>();
+  const calls: string[] = [];
+
+  // Resolving on a later microtask makes a missing `await` fail loudly: a
+  // caller that forgets one gets a pending Promise, which is always truthy.
+  const later = async <T>(name: string, value: T): Promise<T> => {
+    calls.push(name);
+    await Promise.resolve();
+    return value;
+  };
+
+  return {
+    calls,
+
+    async storePendingAuth(backlogState, pending) {
+      pendingAuthorizations.set(backlogState, pending);
+      return later('storePendingAuth', undefined);
+    },
+
+    async consumePendingAuth(backlogState) {
+      const entry = pendingAuthorizations.get(backlogState);
+      pendingAuthorizations.delete(backlogState);
+      return later('consumePendingAuth', entry);
+    },
+
+    async storeAuthCode(code, entry) {
+      authorizationCodes.set(code, entry);
+      return later('storeAuthCode', undefined);
+    },
+
+    async consumeAuthCode(code) {
+      const entry = authorizationCodes.get(code);
+      authorizationCodes.delete(code);
+      if (entry && Date.now() > entry.expiresAt) {
+        return later('consumeAuthCode', undefined);
+      }
+      return later('consumeAuthCode', entry);
+    },
+
+    async getClient(clientId) {
+      return later('getClient', clients.get(clientId));
+    },
+
+    async registerClient(client) {
+      clients.set(client.client_id, client);
+      return later('registerClient', true);
+    },
+
+    async getCachedVerification(token) {
+      const cached = verificationCache.get(token);
+      if (!cached || Date.now() > cached.expiresAt) {
+        return later('getCachedVerification', undefined);
+      }
+      return later(
+        'getCachedVerification',
+        cached.authInfo as Awaited<
+          ReturnType<TokenStore['getCachedVerification']>
+        >
+      );
+    },
+
+    async cacheVerification(token, authInfo, ttlMs) {
+      verificationCache.set(token, {
+        authInfo,
+        expiresAt: Date.now() + ttlMs,
+      });
+      return later('cacheVerification', undefined);
+    },
+
+    async storeMcpToken(mcpToken, entry) {
+      mcpAccessTokens.set(mcpToken, entry);
+      return later('storeMcpToken', undefined);
+    },
+
+    async getMcpToken(mcpToken) {
+      const entry = mcpAccessTokens.get(mcpToken);
+      if (entry && Date.now() > entry.expiresAt) {
+        mcpAccessTokens.delete(mcpToken);
+        return later('getMcpToken', undefined);
+      }
+      return later('getMcpToken', entry);
+    },
+
+    async revokeMcpToken(mcpToken) {
+      mcpAccessTokens.delete(mcpToken);
+      verificationCache.delete(mcpToken);
+      return later('revokeMcpToken', undefined);
+    },
+
+    async storeMcpRefreshToken(mcpRefreshToken, entry) {
+      mcpRefreshTokens.set(mcpRefreshToken, entry);
+      return later('storeMcpRefreshToken', undefined);
+    },
+
+    async consumeMcpRefreshToken(mcpRefreshToken) {
+      const entry = mcpRefreshTokens.get(mcpRefreshToken);
+      mcpRefreshTokens.delete(mcpRefreshToken);
+      return later('consumeMcpRefreshToken', entry);
+    },
+
+    async cleanup() {
+      return later('cleanup', undefined);
+    },
+  };
+};
+
+const base64Url = (buffer: Buffer): string => buffer.toString('base64url');
+
+describe('runHttpMcpServer with an injected asynchronous TokenStore', () => {
+  let shutdown: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await shutdown?.();
+    shutdown = undefined;
+  });
+
+  const start = async (tokenStore: TokenStore): Promise<string> => {
+    const handle = await runHttpMcpServer({
+      host: '127.0.0.1',
+      port: 0,
+      path: '/mcp',
+      version: '0.0.0',
+      enableJsonResponse: true,
+      createServer,
+      oauthConfig,
+      tokenStore,
+    });
+    shutdown = handle.shutdown;
+    const { port } = handle.httpServer.address() as AddressInfo;
+    return `http://127.0.0.1:${port}`;
+  };
+
+  it('completes /register -> /authorize -> /callback -> /token -> /mcp', async () => {
+    const store = createAsyncTokenStore();
+    const origin = await start(store);
+
+    // 1. Dynamic client registration.
+    const registration = await fetch(`${origin}/register`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        redirect_uris: ['https://client.example.com/cb'],
+        client_name: 'async-store-client',
+        application_type: 'web',
+      }),
+    });
+    expect(registration.status).toBe(201);
+    const client = (await registration.json()) as {
+      client_id: string;
+      client_secret: string;
+    };
+    expect(client.client_id).toBeTruthy();
+
+    // 2. Authorization request. The redirect to Backlog carries the state the
+    //    store was asked to hold.
+    const verifier = base64Url(randomBytes(32));
+    const challenge = base64Url(createHash('sha256').update(verifier).digest());
+    const authorize = await fetch(
+      `${origin}/authorize?${new URLSearchParams({
+        client_id: client.client_id,
+        redirect_uri: 'https://client.example.com/cb',
+        response_type: 'code',
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        state: 'client-state',
+      })}`,
+      { redirect: 'manual' }
+    );
+    expect(authorize.status).toBe(302);
+    const backlogState = new URL(
+      authorize.headers.get('location') ?? ''
+    ).searchParams.get('state');
+    expect(backlogState).toBeTruthy();
+
+    // 3. Backlog redirects the browser back with its own code.
+    const callback = await fetch(
+      `${origin}/callback?${new URLSearchParams({
+        code: 'backlog-code',
+        state: backlogState as string,
+      })}`,
+      { redirect: 'manual' }
+    );
+    expect(callback.status).toBe(302);
+    const callbackTarget = new URL(callback.headers.get('location') ?? '');
+    expect(callbackTarget.origin + callbackTarget.pathname).toBe(
+      'https://client.example.com/cb'
+    );
+    expect(callbackTarget.searchParams.get('state')).toBe('client-state');
+    const mcpCode = callbackTarget.searchParams.get('code');
+    expect(mcpCode).toBeTruthy();
+
+    // 4. Token exchange.
+    const token = await fetch(`${origin}/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: client.client_id,
+        client_secret: client.client_secret,
+        code: mcpCode as string,
+        code_verifier: verifier,
+        redirect_uri: 'https://client.example.com/cb',
+      }).toString(),
+    });
+    expect(token.status).toBe(200);
+    const tokens = (await token.json()) as {
+      access_token: string;
+      refresh_token: string;
+    };
+    expect(tokens.access_token).toBeTruthy();
+
+    // 5. An authenticated MCP call.
+    const mcp = await fetch(`${origin}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        authorization: `Bearer ${tokens.access_token}`,
+        'mcp-method': 'tools/list',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: { _meta: MODERN_ENVELOPE },
+      }),
+    });
+    expect(mcp.status).toBe(200);
+    expect(await mcp.text()).toContain('ping');
+
+    // Every stage went through the injected store rather than a default one.
+    expect(store.calls).toEqual(
+      expect.arrayContaining([
+        'registerClient',
+        'getClient',
+        'storePendingAuth',
+        'consumePendingAuth',
+        'storeAuthCode',
+        'consumeAuthCode',
+        'storeMcpToken',
+        'storeMcpRefreshToken',
+        'getMcpToken',
+        'cacheVerification',
+      ])
+    );
+  });
+
+  it('refreshes an access token through the same store', async () => {
+    const store = createAsyncTokenStore();
+    const origin = await start(store);
+
+    await store.registerClient({
+      client_id: 'c-refresh',
+      client_secret: 's-refresh',
+      client_id_issued_at: 0,
+      client_secret_expires_at: 0,
+      redirect_uris: ['https://client.example.com/cb'],
+    });
+    await store.storeMcpRefreshToken('mcp-refresh', {
+      backlogRefreshToken: 'bl-refresh',
+      clientId: 'c-refresh',
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+
+    const res = await fetch(`${origin}/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: 'c-refresh',
+        client_secret: 's-refresh',
+        refresh_token: 'mcp-refresh',
+      }).toString(),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { access_token: string };
+    expect(body.access_token).toBeTruthy();
+    expect(store.calls).toContain('consumeMcpRefreshToken');
+  });
+
+  it('rejects an unknown bearer token', async () => {
+    const store = createAsyncTokenStore();
+    const origin = await start(store);
+
+    const res = await fetch(`${origin}/mcp`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        authorization: 'Bearer not-a-token',
+        'mcp-method': 'tools/list',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: { _meta: MODERN_ENVELOPE },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(store.calls).toContain('getMcpToken');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ import { default as env } from 'env-var';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { getBacklogOAuthConfig } from './auth/backlogOAuthConfig.js';
+import { loadTokenStoreModule } from './auth/loadTokenStoreModule.js';
 import { createTokenStore } from './auth/tokenStore.js';
+import type { TokenStore } from './auth/tokenStore.js';
 import { createDescriptionHelper } from './createDescriptionHelper.js';
 import { loadDescriptionOverrides } from './loadDescriptionOverrides.js';
 import { createBacklogMcpServer } from './createBacklogMcpServer.js';
@@ -96,6 +98,12 @@ const argv = yargs(hideBin(process.argv))
       'Comma-separated allowed Origin header hostnames for browser-based clients. Defaults to the localhost set on a loopback bind, and to no Origin check otherwise',
     default: env.get('MCP_HTTP_ALLOWED_ORIGINS').default('').asString(),
   })
+  .option('token-store-module', {
+    type: 'string',
+    describe:
+      'Path or package name of a module whose default export builds the OAuth TokenStore. Defaults to an in-memory store, which is lost on restart and not shared between instances',
+    default: env.get('MCP_TOKEN_STORE_MODULE').default('').asString(),
+  })
   .option('max-tokens', {
     type: 'number',
     describe: 'Maximum number of tokens allowed in the response',
@@ -155,12 +163,36 @@ const clientRegistry = oauthConfig
   : createBacklogClientRegistry();
 const backlog = clientRegistry.createScopedClient();
 
-const tokenStore = oauthConfig ? createTokenStore() : undefined;
 let cleanupTimer: ReturnType<typeof setInterval> | undefined;
-if (tokenStore) {
-  cleanupTimer = setInterval(() => tokenStore.cleanup(), 5 * 60 * 1000);
+
+// Loading an external store needs `await import`, so the store is built inside
+// `main()` rather than at module scope. Without `--token-store-module` this is
+// the same in-memory store as before, built at the same point in the startup
+// sequence relative to everything that reads it.
+const createConfiguredTokenStore = async (): Promise<
+  TokenStore | undefined
+> => {
+  if (!oauthConfig) return undefined;
+
+  const specifier = argv.tokenStoreModule.trim();
+  const store = specifier
+    ? await loadTokenStoreModule(specifier)
+    : createTokenStore();
+
+  // An external store's cleanup can reject, and an unhandled rejection would
+  // take the process down through the handler installed above.
+  cleanupTimer = setInterval(
+    () => {
+      void Promise.resolve(store.cleanup()).catch((err) =>
+        logger.error({ err }, 'Token store cleanup failed')
+      );
+    },
+    5 * 60 * 1000
+  );
   cleanupTimer.unref();
-}
+
+  return store;
+};
 
 const useFields = argv.optimizeResponse;
 
@@ -236,6 +268,8 @@ function normalizeHttpPath(p: string): string {
 }
 
 async function main() {
+  const tokenStore = await createConfiguredTokenStore();
+
   if (oauthConfig && argv.transport === 'stdio') {
     logger.warn(
       'OAuth is configured but transport is stdio. OAuth is only available with HTTP transport.'

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -30,3 +30,20 @@ export type {
 } from './types/tool.js';
 export type { Toolset, ToolsetGroup } from './types/toolsets.js';
 export type { ErrorLike, SafeResult } from './types/result.js';
+
+/**
+ * The OAuth state contract, so a deployment can back client registrations and
+ * tokens with something that outlives a restart and is shared between
+ * instances. Types only: the server that consumes one is the CLI, which loads
+ * an implementation named by `--token-store-module`.
+ */
+export type {
+  TokenStore,
+  TokenStoreFactory,
+  OAuthClientInfo,
+  PendingAuthorization,
+  AuthCodeEntry,
+  McpTokenEntry,
+  McpRefreshEntry,
+  BacklogTokenData,
+} from './auth/tokenStore.js';


### PR DESCRIPTION
Implements options (1) and (2) from #215: make `TokenStore` a declared contract that an asynchronous implementation can satisfy, and give a deployment a way to supply one without forking.

## Why

`TokenStore` was `ReturnType<typeof createTokenStore>` (`src/auth/tokenStore.ts:65`), so the type was whatever the in-memory store happened to be — six `Map`s behind synchronous methods. Any external store is asynchronous and therefore could not be typed as a `TokenStore`, which is what made the README's note a design boundary rather than a temporary state:

> Client registrations and tokens are stored in memory and will be lost on server restart.

The consequences are visible to users rather than to operators: every deploy costs every user a re-authorization, and a second instance cannot serve a session the first one started. Load-balancer stickiness does not close that gap — `/authorize` and `/callback` arrive from the user's browser while `/token` and `/mcp` arrive from the MCP client, so no cookie can land them on the same process. #215 has the detail.

**One correction to #215.** The issue says there is no injection point. That is wrong: `runHttpMcpServer` already accepts `tokenStore` (`src/httpMcpServer.ts:32`), and `src/index.ts:184` builds one and passes it. What is missing is a way to reach that parameter from outside the package. So (2) is narrower than the issue makes it sound, and this PR is correspondingly smaller.

## What changed

**(1) `TokenStore` is a declared interface.** Every method returns `T | Promise<T>`. `PendingAuthorization`, `AuthCodeEntry` and `McpRefreshEntry` become exported, since an external implementation has to name them. The default store stays synchronous and its object literal is checked with `satisfies TokenStore` rather than annotated, so its methods keep their exact synchronous types and the existing `tokenStore.test.ts` is unchanged. Call sites gained `await`: 14 in `oauthRoutes.ts`, 3 in `bearerAuthMiddleware.ts`. Two of those are the ones that matter — `if (!store.registerClient(client))` and `const client = store.getClient(clientId)` would otherwise test a Promise for truthiness.

The interface documents two obligations the type cannot express: `consumePendingAuth`, `consumeAuthCode` and `consumeMcpRefreshToken` must read and delete atomically, since an authorization code replayed against two instances would otherwise mint two token pairs; and an expired entry must never be served, though an implementation may leave that to a native TTL.

**(2) `--token-store-module` / `MCP_TOKEN_STORE_MODULE`.** Names a module whose default export builds the store. `src/auth/loadTokenStoreModule.ts` imports it, calls the factory, and checks that all thirteen methods are present — a store missing one fails at startup naming what is missing, rather than midway through an authorization with a `TypeError` from inside a route handler. A relative or absolute path resolves against the working directory rather than against the loader, which is inside the installed package. `src/lib.ts` exports `TokenStore` and the boundary types for implementations written in TypeScript.

### Why the CLI rather than a library export

The obvious shape for (2) is to export `runHttpMcpServer` from `src/lib.ts`. Two things argue against it, and a third against the workaround:

- `src/lib.ts` states an invariant in its header: *"Nothing reachable from here may touch a Node built-in."* `runHttpMcpServer` imports `@hono/node-server`, and `runWithAccessToken` reaches `node:async_hooks` (`src/auth/backlogAuthContext.ts:4`).
- A `./node` subpath would preserve that, but adds a package export entry — a public API surface this PR would be asking you to own on the strength of one function.
- Splitting `runHttpMcpServer` into a runtime-free app factory plus a thin Node wrapper does not work as stated either. The OAuth routes reach `node:crypto` (`src/auth/oauthRoutes.ts:4`), and `logger` initialises pino against `process.env` at import time. Making the app factory genuinely runtime-free means inverting logger, the access-token context and the OAuth routes into parameters — #137's shape, and not something this PR should smuggle in.

The CLI flag adds no package exports and no runtime code reachable from `src/lib.ts`; the only new exports there are types, which disappear at compile time. It also matches how this is actually deployed: a published image plus one module, rather than a bespoke entry point wrapping the library.

**In the interest of full disclosure:** `src/lib.ts` does not currently uphold its own invariant. `composeToolHandler` → `wrapWithOrganizationContext` → `src/utils/backlogOrganizationContext.ts:1` reaches `node:async_hooks` today. I have left that alone — it is unrelated to this change and worth its own decision — but it is why I did not treat the invariant as settling the question on its own.

## What is not included

- **No Redis, DynamoDB or Durable Object implementation, and no new dependency.** The value asked for in #215 is the seam; a concrete store is surface this repo would have to own and a dependency most users do not need. #137 shipped `durableTokenStore.ts` alongside 21 other changed files and was closed without review.
- **No change to the default.** Without `--token-store-module` the server builds the same in-memory store as before.

## Behaviour when no store is supplied

Unchanged, with one structural note. Loading an external module needs `await import`, so the store is now built inside `main()` instead of at module scope. Nothing reads it earlier: the only consumers are the `runHttpMcpServer` call and the cleanup timer, which is created alongside it and still `unref`'d. The `--export-descriptions` path exits before either.

The cleanup timer now handles a rejected `cleanup()`. In-memory cleanup cannot reject, but a network-backed one can, and an unhandled rejection would take the process down through the handler in `src/index.ts:42`.

## Tests

`src/httpMcpServer.oauth.test.ts` (new) drives the whole flow against a `TokenStore` whose every method is `async` and resolves on a later microtask — so a missing `await` anywhere produces a pending Promise, which is always truthy, and the assertion fails. This is the part that demonstrates the contract is not shaped around one implementation:

- `/register` → `/authorize` → `/callback` → `/token` → `tools/list` on `/mcp` with the issued bearer token, all 2xx/302, asserting each stage went through the injected store
- refresh-token grant through the same store
- an unknown bearer token is rejected with `401`

`src/auth/loadTokenStoreModule.test.ts` (new) covers the loader against modules written to a temp directory and imported by absolute path — the case that matters, since a real store lives outside this package: a well-formed async factory; no default export; a factory returning a non-object; a store missing methods, asserting the error names them; an unresolvable specifier.

`oauthRoutes.test.ts` and `tokenStore.test.ts` each changed by one line: `store` is typed `ReturnType<typeof createTokenStore>` instead of `TokenStore`, since those suites exercise the synchronous default and call it without `await`.

## Verified

`pnpm test` (93 files, 493 tests), `pnpm lint`, `pnpm format` and `pnpm build` all pass on Node 24.14.1 / pnpm 10.34.4.

Also checked by hand against the built CLI, since the loader path is CLI wiring that unit tests do not reach:

| Run | `POST /register` | `POST /mcp` no auth | `POST /mcp` bad token | `GET /health` |
| --- | --- | --- | --- | --- |
| default (no flag) | `201` | `401` | — | `200` |
| `--token-store-module ./store.mjs` | `201` | `401` | `401` | — |

With the flag, the module's own logging confirms `registerClient` and `getMcpToken` were served by it rather than by a default store. A module with no default export fails at startup with `Token store module "…" must default-export a function returning a TokenStore.`
