### PR TITLE
fix: treat a Backlog 401 as an authentication event under OAuth

### DIFF
--- a/src/auth/backlogAuthContext.test.ts
+++ b/src/auth/backlogAuthContext.test.ts
@@ -1,10 +1,12 @@
 // Copyright (c) 2025 Nulab inc.
 // Licensed under the MIT License.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   runWithAccessToken,
   getCurrentAccessToken,
+  reportBacklogAuthError,
+  hasBacklogAuthErrorBeenReported,
 } from './backlogAuthContext.js';
 
 describe('backlogAuthContext', () => {
@@ -31,5 +33,88 @@ describe('backlogAuthContext', () => {
     });
     expect(innerToken).toBe('inner');
     expect(outerToken).toBe('outer');
+  });
+
+  describe('reportBacklogAuthError', () => {
+    it('invokes the callback and records the report', async () => {
+      const onAuthError = vi.fn();
+      let reported = false;
+
+      await runWithAccessToken(
+        'test-token',
+        async () => {
+          reportBacklogAuthError();
+          reported = hasBacklogAuthErrorBeenReported();
+        },
+        onAuthError
+      );
+
+      expect(onAuthError).toHaveBeenCalledTimes(1);
+      expect(reported).toBe(true);
+    });
+
+    // A single tool call can fan out into several Backlog requests; the token
+    // only needs revoking once.
+    it('invokes the callback once however often it is reported', async () => {
+      const onAuthError = vi.fn();
+
+      await runWithAccessToken(
+        'test-token',
+        async () => {
+          reportBacklogAuthError();
+          reportBacklogAuthError();
+          reportBacklogAuthError();
+        },
+        onAuthError
+      );
+
+      expect(onAuthError).toHaveBeenCalledTimes(1);
+    });
+
+    // API-key mode never establishes the context, which is what keeps a 401 on
+    // the stdio transport an ordinary tool error.
+    it('is a no-op outside of runWithAccessToken', () => {
+      expect(() => reportBacklogAuthError()).not.toThrow();
+      expect(hasBacklogAuthErrorBeenReported()).toBe(false);
+    });
+
+    it('reports nothing when no failure occurred', async () => {
+      const onAuthError = vi.fn();
+      let reported = true;
+
+      await runWithAccessToken(
+        'test-token',
+        async () => {
+          reported = hasBacklogAuthErrorBeenReported();
+        },
+        onAuthError
+      );
+
+      expect(onAuthError).not.toHaveBeenCalled();
+      expect(reported).toBe(false);
+    });
+
+    it('does not leak a report to an enclosing context', async () => {
+      const outer = vi.fn();
+      const inner = vi.fn();
+      let outerReported = true;
+
+      await runWithAccessToken(
+        'outer',
+        async () => {
+          await runWithAccessToken(
+            'inner',
+            async () => reportBacklogAuthError(),
+            inner
+          );
+          outerReported = hasBacklogAuthErrorBeenReported();
+        },
+        outer
+      );
+
+      expect(inner).toHaveBeenCalledTimes(1);
+      expect(outer).not.toHaveBeenCalled();
+      expect(outerReported).toBe(false);
+    });
   });
 });

--- a/src/auth/backlogAuthContext.ts
+++ b/src/auth/backlogAuthContext.ts
@@ -4,7 +4,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 type BacklogAuthContext = {
-  accessToken: string | undefined;
+  // Not optional: a context exists only for a request the bearer middleware
+  // already resolved a stored token for. Keeping it non-nullable is what makes
+  // "a context is present" and "a token is present" the same question, so the
+  // wording of an auth failure and the decision to revoke cannot disagree.
+  accessToken: string;
   onAuthError?: () => void;
   authErrorReported: boolean;
 };
@@ -21,7 +25,7 @@ const authContextStorage = new AsyncLocalStorage<BacklogAuthContext>();
  * inspecting the outcome afterwards to invalidate anything.
  */
 export function runWithAccessToken<T>(
-  token: string | undefined,
+  token: string,
   fn: () => Promise<T>,
   onAuthError?: () => void
 ): Promise<T> {

--- a/src/auth/backlogAuthContext.ts
+++ b/src/auth/backlogAuthContext.ts
@@ -3,15 +3,52 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-const accessTokenStorage = new AsyncLocalStorage<string | undefined>();
+type BacklogAuthContext = {
+  accessToken: string | undefined;
+  onAuthError?: () => void;
+  authErrorReported: boolean;
+};
 
+const authContextStorage = new AsyncLocalStorage<BacklogAuthContext>();
+
+/**
+ * Runs `fn` with the OAuth access token of the current request in scope.
+ *
+ * `onAuthError` is invoked the first time a Backlog call inside `fn` is
+ * rejected with an authentication error. It runs at the moment of detection
+ * rather than after `fn` settles, because a response that has already upgraded
+ * to SSE resolves before its handler finishes — the caller cannot rely on
+ * inspecting the outcome afterwards to invalidate anything.
+ */
 export function runWithAccessToken<T>(
   token: string | undefined,
-  fn: () => Promise<T>
+  fn: () => Promise<T>,
+  onAuthError?: () => void
 ): Promise<T> {
-  return accessTokenStorage.run(token, fn);
+  return authContextStorage.run(
+    { accessToken: token, onAuthError, authErrorReported: false },
+    fn
+  );
 }
 
 export function getCurrentAccessToken(): string | undefined {
-  return accessTokenStorage.getStore();
+  return authContextStorage.getStore()?.accessToken;
+}
+
+/**
+ * Reports that Backlog rejected the credentials of the current request.
+ *
+ * A no-op outside {@link runWithAccessToken}, which is how API-key mode stays
+ * unaffected: nothing establishes this context on the stdio transport.
+ */
+export function reportBacklogAuthError(): void {
+  const context = authContextStorage.getStore();
+  if (!context || context.authErrorReported) return;
+  context.authErrorReported = true;
+  context.onAuthError?.();
+}
+
+/** Whether {@link reportBacklogAuthError} was called in the current context. */
+export function hasBacklogAuthErrorBeenReported(): boolean {
+  return authContextStorage.getStore()?.authErrorReported ?? false;
 }

--- a/src/auth/bearerAuthMiddleware.test.ts
+++ b/src/auth/bearerAuthMiddleware.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Hono } from 'hono';
 import { createBearerAuthMiddleware } from './bearerAuthMiddleware.js';
+import { reportBacklogAuthError } from './backlogAuthContext.js';
 import { createTokenStore } from './tokenStore.js';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 
@@ -116,5 +117,76 @@ describe('createBearerAuthMiddleware', () => {
       headers: { Authorization: 'Bearer mcp-token-3' },
     });
     expect(res.status).toBe(401);
+  });
+
+  // Regression for a Backlog 401 arriving as tool output over transport 200:
+  // the client sees a healthy connection and is never told to re-authenticate.
+  describe('when a downstream Backlog call reports an auth error', () => {
+    let failing: Hono;
+
+    beforeEach(() => {
+      failing = new Hono();
+      failing.use('/mcp', createBearerAuthMiddleware(store, config, '/mcp'));
+      failing.post('/mcp', (c) => {
+        reportBacklogAuthError();
+        return c.json({ ok: true });
+      });
+
+      store.storeMcpToken('mcp-token-live', {
+        backlogAccessToken: 'bl-token-live',
+        clientId: 'c1',
+        expiresAt: Date.now() + 3600_000,
+      });
+      store.cacheVerification(
+        'mcp-token-live',
+        { token: 'bl-token-live', clientId: '1', scopes: [], expiresAt: 0 },
+        300_000
+      );
+    });
+
+    const call = (app: Hono) =>
+      app.request('/mcp', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer mcp-token-live' },
+      });
+
+    it('replaces the tool result with 401 and WWW-Authenticate', async () => {
+      const res = await call(failing);
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get('www-authenticate')).toContain(
+        'resource_metadata'
+      );
+      const body = await res.json();
+      expect(body.error).toBe('invalid_token');
+    });
+
+    it('revokes the MCP token and its cached verification', async () => {
+      await call(failing);
+
+      expect(store.getMcpToken('mcp-token-live')).toBeUndefined();
+      expect(store.getCachedVerification('mcp-token-live')).toBeUndefined();
+    });
+
+    // The revocation, not the rewritten response, is what makes this
+    // recoverable: a response that upgraded to SSE has already been sent.
+    it('answers the next request on the same token with 401', async () => {
+      await call(failing);
+      const res = await call(app);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error_description).toContain('Unknown or expired');
+    });
+
+    it('leaves a request that reported nothing untouched', async () => {
+      const res = await call(app);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+      expect(store.getMcpToken('mcp-token-live')).toMatchObject({
+        backlogAccessToken: 'bl-token-live',
+      });
+    });
   });
 });

--- a/src/auth/bearerAuthMiddleware.ts
+++ b/src/auth/bearerAuthMiddleware.ts
@@ -5,6 +5,10 @@ import type { MiddlewareHandler } from 'hono';
 import type { AuthInfo } from '@modelcontextprotocol/server';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 import { verifyBacklogToken } from './backlogOAuthClient.js';
+import {
+  hasBacklogAuthErrorBeenReported,
+  runWithAccessToken,
+} from './backlogAuthContext.js';
 import type { TokenStore } from './tokenStore.js';
 import { logger } from '../utils/logger.js';
 
@@ -18,14 +22,24 @@ export function createBearerAuthMiddleware(
   const prmPath = mcpPath === '/' ? '' : mcpPath;
   const resourceMetadataUrl = `${config.serverBaseUrl}/.well-known/oauth-protected-resource${prmPath}`;
 
+  const wwwAuthenticate = (description?: string): string =>
+    description
+      ? `Bearer error="invalid_token", error_description="${description}", resource_metadata="${resourceMetadataUrl}"`
+      : `Bearer resource_metadata="${resourceMetadataUrl}"`;
+
   return async (c, next) => {
+    const unauthorized = (description: string, header = description) => {
+      c.header('WWW-Authenticate', wwwAuthenticate(header));
+      return c.json(
+        { error: 'invalid_token', error_description: description },
+        401
+      );
+    };
+
     const authHeader = c.req.header('authorization');
 
     if (!authHeader) {
-      c.header(
-        'WWW-Authenticate',
-        `Bearer resource_metadata="${resourceMetadataUrl}"`
-      );
+      c.header('WWW-Authenticate', wwwAuthenticate());
       return c.json(
         {
           error: 'invalid_token',
@@ -37,65 +51,67 @@ export function createBearerAuthMiddleware(
 
     const [type, mcpToken] = authHeader.split(' ');
     if (type?.toLowerCase() !== 'bearer' || !mcpToken) {
-      c.header(
-        'WWW-Authenticate',
-        `Bearer error="invalid_token", error_description="Invalid Authorization header format", resource_metadata="${resourceMetadataUrl}"`
-      );
-      return c.json(
-        { error: 'invalid_token', error_description: 'Expected Bearer token' },
-        401
+      return unauthorized(
+        'Expected Bearer token',
+        'Invalid Authorization header format'
       );
     }
 
     const tokenEntry = store.getMcpToken(mcpToken);
     if (!tokenEntry) {
-      c.header(
-        'WWW-Authenticate',
-        `Bearer error="invalid_token", error_description="Unknown or expired token", resource_metadata="${resourceMetadataUrl}"`
-      );
-      return c.json(
-        {
-          error: 'invalid_token',
-          error_description: 'Unknown or expired token',
-        },
-        401
-      );
+      return unauthorized('Unknown or expired token');
     }
 
-    const cached = store.getCachedVerification(mcpToken);
-    if (cached) {
-      c.set('authInfo', cached);
-      await next();
-      return;
+    let authInfo = store.getCachedVerification(mcpToken);
+
+    if (!authInfo) {
+      try {
+        const user = await verifyBacklogToken(
+          config.backlogDomain,
+          tokenEntry.backlogAccessToken
+        );
+        authInfo = {
+          token: tokenEntry.backlogAccessToken,
+          clientId: String(user.id),
+          scopes: [],
+          expiresAt: Math.floor(Date.now() / 1000) + CACHE_TTL_MS / 1000,
+        } satisfies AuthInfo;
+        store.cacheVerification(mcpToken, authInfo, CACHE_TTL_MS);
+      } catch (err) {
+        logger.warn({ err }, 'Bearer token verification failed');
+        return unauthorized('Token verification failed');
+      }
     }
 
-    try {
-      const user = await verifyBacklogToken(
-        config.backlogDomain,
-        tokenEntry.backlogAccessToken
+    c.set('authInfo', authInfo);
+
+    // The stored token is the only credential a downstream Backlog call has, so
+    // Backlog rejecting it is an authentication event and not a tool failure.
+    // Dropping the entry here is what lets the client recover: the next request
+    // fails the `getMcpToken` check above and is told to re-authenticate.
+    //
+    // Invalidation happens the moment the failure is reported rather than after
+    // `next()` settles, because a response that upgraded to SSE resolves before
+    // its handler has run.
+    const onAuthError = () => {
+      logger.warn(
+        { clientId: tokenEntry.clientId },
+        'Backlog rejected the stored access token; revoking the MCP token'
       );
-      const authInfo: AuthInfo = {
-        token: tokenEntry.backlogAccessToken,
-        clientId: String(user.id),
-        scopes: [],
-        expiresAt: Math.floor(Date.now() / 1000) + CACHE_TTL_MS / 1000,
-      };
-      store.cacheVerification(mcpToken, authInfo, CACHE_TTL_MS);
-      c.set('authInfo', authInfo);
-      await next();
-    } catch (err) {
-      logger.warn({ err }, 'Bearer token verification failed');
-      c.header(
-        'WWW-Authenticate',
-        `Bearer error="invalid_token", error_description="Token verification failed", resource_metadata="${resourceMetadataUrl}"`
-      );
-      return c.json(
-        {
-          error: 'invalid_token',
-          error_description: 'Token verification failed',
-        },
-        401
-      );
-    }
+      store.revokeMcpToken(mcpToken);
+    };
+
+    await runWithAccessToken(
+      tokenEntry.backlogAccessToken,
+      async () => {
+        await next();
+        // Read inside the context: `next()` resolving is not the end of the
+        // async scope, but it is the point at which the response is decided.
+        if (hasBacklogAuthErrorBeenReported()) {
+          c.res = unauthorized('Backlog rejected the access token');
+        }
+      },
+      onAuthError
+    );
   };
 }

--- a/src/auth/tokenStore.test.ts
+++ b/src/auth/tokenStore.test.ts
@@ -232,6 +232,56 @@ describe('createTokenStore', () => {
     });
   });
 
+  describe('revokeMcpToken', () => {
+    const seed = () => {
+      store.storeMcpToken('mcp-token', {
+        backlogAccessToken: 'bl-at',
+        clientId: 'c1',
+        expiresAt: Date.now() + 3600_000,
+      });
+      store.cacheVerification(
+        'mcp-token',
+        { token: 'bl-at', clientId: '1', scopes: [], expiresAt: 0 },
+        300_000
+      );
+      store.storeMcpRefreshToken('mcp-refresh', {
+        backlogRefreshToken: 'bl-rt',
+        clientId: 'c1',
+        expiresAt: Date.now() + 3600_000,
+      });
+    };
+
+    it('drops the access token and its cached verification', () => {
+      seed();
+
+      store.revokeMcpToken('mcp-token');
+
+      expect(store.getMcpToken('mcp-token')).toBeUndefined();
+      expect(store.getCachedVerification('mcp-token')).toBeUndefined();
+    });
+
+    // A Backlog 401 says the access token is spent, not that the grant is gone,
+    // so the client should still be able to recover through the refresh grant.
+    it('leaves the refresh token usable', () => {
+      seed();
+
+      store.revokeMcpToken('mcp-token');
+
+      expect(store.consumeMcpRefreshToken('mcp-refresh')).toMatchObject({
+        backlogRefreshToken: 'bl-rt',
+      });
+    });
+
+    it('is a no-op for an unknown token', () => {
+      seed();
+
+      expect(() => store.revokeMcpToken('other-token')).not.toThrow();
+      expect(store.getMcpToken('mcp-token')).toMatchObject({
+        backlogAccessToken: 'bl-at',
+      });
+    });
+  });
+
   describe('cleanup', () => {
     it('removes expired entries including MCP tokens', () => {
       store.storePendingAuth('s1', {

--- a/src/auth/tokenStore.ts
+++ b/src/auth/tokenStore.ts
@@ -154,6 +154,20 @@ export function createTokenStore() {
       return entry;
     },
 
+    /**
+     * Drops an MCP access token and its cached verification, so the next
+     * request on it is rejected by the bearer middleware.
+     *
+     * The refresh token is deliberately left in place: a Backlog 401 says the
+     * access token is spent, not that the grant is gone, so a client should be
+     * able to recover through the refresh grant before falling back to a full
+     * re-authorization.
+     */
+    revokeMcpToken(mcpToken: string): void {
+      mcpAccessTokens.delete(mcpToken);
+      verificationCache.delete(mcpToken);
+    },
+
     storeMcpRefreshToken(
       mcpRefreshToken: string,
       entry: McpRefreshEntry

--- a/src/backlog/backlogErrorHandler.test.ts
+++ b/src/backlog/backlogErrorHandler.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Nulab inc.
+// Licensed under the MIT License.
+
+import { describe, it, expect, vi } from 'vitest';
+import { runWithAccessToken } from '../auth/backlogAuthContext.js';
+import { backlogErrorHandler } from './backlogErrorHandler.js';
+
+const authError = {
+  _name: 'BacklogAuthError',
+  _status: 401,
+  _url: 'https://example.backlog.com/api/v2/users/myself',
+};
+
+const apiError = {
+  _name: 'BacklogApiError',
+  _status: 404,
+  _url: 'https://example.backlog.com/api/v2/issues/1',
+  _body: { errors: [{ message: 'No issue.', code: 5 }] },
+};
+
+describe('backlogErrorHandler', () => {
+  // API-key mode: no request context, so a 401 stays an ordinary tool error.
+  it('reports nothing outside an OAuth request context', () => {
+    const result = backlogErrorHandler(authError);
+
+    expect(result.kind).toBe('error');
+    expect(result.message).toContain('API key');
+  });
+
+  it('reports the failure inside an OAuth request context', async () => {
+    const onAuthError = vi.fn();
+
+    const result = await runWithAccessToken(
+      'bl-token',
+      async () => backlogErrorHandler(authError),
+      onAuthError
+    );
+
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(result.message).toContain('Re-authenticate');
+  });
+
+  it('leaves a non-authentication failure alone', async () => {
+    const onAuthError = vi.fn();
+
+    const result = await runWithAccessToken(
+      'bl-token',
+      async () => backlogErrorHandler(apiError),
+      onAuthError
+    );
+
+    expect(onAuthError).not.toHaveBeenCalled();
+    expect(result.message).toContain('No issue.');
+  });
+});

--- a/src/backlog/backlogErrorHandler.ts
+++ b/src/backlog/backlogErrorHandler.ts
@@ -1,8 +1,24 @@
+import {
+  getCurrentAccessToken,
+  reportBacklogAuthError,
+} from '../auth/backlogAuthContext.js';
 import { ErrorLike } from '../types/result.js';
 import { parseBacklogAPIError } from './parseBacklogAPIError.js';
 
 export const backlogErrorHandler = (err: unknown): ErrorLike => {
-  const parsed = parseBacklogAPIError(err);
+  // Only an OAuth request carries an access token in its context; the stdio
+  // transport authenticates with an API key and never establishes one.
+  const authMode = getCurrentAccessToken() ? 'oauth' : 'apiKey';
+  const parsed = parseBacklogAPIError(err, { authMode });
+
+  // Backlog rejecting an OAuth token is authoritative: the credential this
+  // request was issued is spent. Reporting it lets the transport invalidate the
+  // token and tell the client to re-authenticate, instead of returning the
+  // failure as tool output the client cannot act on.
+  if (parsed.type === 'BacklogAuthError') {
+    reportBacklogAuthError();
+  }
+
   return {
     kind: 'error',
     message: parsed.message,

--- a/src/backlog/backlogErrorHandler.ts
+++ b/src/backlog/backlogErrorHandler.ts
@@ -7,8 +7,11 @@ import { parseBacklogAPIError } from './parseBacklogAPIError.js';
 
 export const backlogErrorHandler = (err: unknown): ErrorLike => {
   // Only an OAuth request carries an access token in its context; the stdio
-  // transport authenticates with an API key and never establishes one.
-  const authMode = getCurrentAccessToken() ? 'oauth' : 'apiKey';
+  // transport authenticates with an API key and never establishes one. The
+  // comparison is against `undefined` rather than truthiness so this asks
+  // exactly what `reportBacklogAuthError` asks — whether a context exists —
+  // and the two cannot answer differently for the same request.
+  const authMode = getCurrentAccessToken() !== undefined ? 'oauth' : 'apiKey';
   const parsed = parseBacklogAPIError(err, { authMode });
 
   // Backlog rejecting an OAuth token is authoritative: the credential this

--- a/src/backlog/parseBacklogAPIError.test.ts
+++ b/src/backlog/parseBacklogAPIError.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 Nulab inc.
+// Licensed under the MIT License.
+
+import { describe, it, expect } from 'vitest';
+import { parseBacklogAPIError } from './parseBacklogAPIError.js';
+
+const authError = {
+  _name: 'BacklogAuthError',
+  _status: 401,
+  _url: 'https://example.backlog.com/api/v2/users/myself',
+};
+
+describe('parseBacklogAPIError', () => {
+  describe('BacklogAuthError', () => {
+    it('points an API-key deployment at its API key', () => {
+      const parsed = parseBacklogAPIError(authError);
+
+      expect(parsed.type).toBe('BacklogAuthError');
+      expect(parsed.status).toBe(401);
+      expect(parsed.message).toContain('API key');
+    });
+
+    it('defaults to the API-key wording, so stdio is unaffected', () => {
+      expect(parseBacklogAPIError(authError, {}).message).toBe(
+        parseBacklogAPIError(authError, { authMode: 'apiKey' }).message
+      );
+    });
+
+    // There is no API key to check in OAuth mode, so the original wording sent
+    // the user somewhere there was nothing to fix.
+    it('tells an OAuth deployment to re-authenticate instead', () => {
+      const parsed = parseBacklogAPIError(authError, { authMode: 'oauth' });
+
+      expect(parsed.type).toBe('BacklogAuthError');
+      expect(parsed.message).not.toContain('API key');
+      expect(parsed.message).toContain('Re-authenticate');
+    });
+  });
+
+  describe('other errors', () => {
+    it('reports a Backlog API error with its code', () => {
+      const parsed = parseBacklogAPIError(
+        {
+          _name: 'BacklogApiError',
+          _status: 404,
+          _url: 'https://example.backlog.com/api/v2/issues/1',
+          _body: { errors: [{ message: 'No issue.', code: 5 }] },
+        },
+        { authMode: 'oauth' }
+      );
+
+      expect(parsed.type).toBe('BacklogApiError');
+      expect(parsed.code).toBe(5);
+      expect(parsed.message).toContain('No issue.');
+    });
+
+    it('falls back to the message of a plain error', () => {
+      const parsed = parseBacklogAPIError(new Error('socket hang up'));
+
+      expect(parsed.type).toBe('UnknownError');
+      expect(parsed.message).toBe('socket hang up');
+    });
+  });
+});

--- a/src/backlog/parseBacklogAPIError.ts
+++ b/src/backlog/parseBacklogAPIError.ts
@@ -26,7 +26,22 @@ export type ParsedBacklogAPIError = {
   url?: string;
 };
 
-export function parseBacklogAPIError(err: unknown): ParsedBacklogAPIError {
+/**
+ * How the rejected request was authenticated. It decides only the wording of an
+ * authentication failure: in OAuth mode there is no API key to go and check.
+ */
+export type BacklogAuthMode = 'apiKey' | 'oauth';
+
+const authErrorMessage = (status: number, authMode: BacklogAuthMode): string =>
+  authMode === 'oauth'
+    ? `Authentication failed (HTTP ${status}). The Backlog access token was rejected. Re-authenticate with Backlog, or check that your account has permission for this resource.`
+    : `Authentication failed (HTTP ${status}). Please check your API key or permissions.`;
+
+export function parseBacklogAPIError(
+  err: unknown,
+  options: { authMode?: BacklogAuthMode } = {}
+): ParsedBacklogAPIError {
+  const { authMode = 'apiKey' } = options;
   const e = err as MaybeBacklogErrorObject;
 
   if (e._name && e._status && e._url) {
@@ -39,7 +54,7 @@ export function parseBacklogAPIError(err: unknown): ParsedBacklogAPIError {
     if (e._name === 'BacklogAuthError') {
       return {
         type: 'BacklogAuthError',
-        message: `Authentication failed (HTTP ${status}). Please check your API key or permissions.`,
+        message: authErrorMessage(status, authMode),
         status,
         url,
       };

--- a/src/httpMcpServer.test.ts
+++ b/src/httpMcpServer.test.ts
@@ -32,7 +32,11 @@ const createServer = (): BacklogMCPServer => {
   return server;
 };
 
-type RawResponse = { status: number; body: string };
+type RawResponse = {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+};
 
 /**
  * Raw node:http request. `fetch` treats `Host` as a forbidden header, so the
@@ -59,7 +63,9 @@ const send = (
         let body = '';
         res.setEncoding('utf8');
         res.on('data', (chunk) => (body += chunk));
-        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+        res.on('end', () =>
+          resolve({ status: res.statusCode ?? 0, headers: res.headers, body })
+        );
       }
     );
     req.on('error', reject);
@@ -311,6 +317,16 @@ describe('runHttpMcpServer', () => {
 
       expect(res.status).toBe(401);
       expect(JSON.parse(res.body).error).toBe('invalid_token');
+      // The header, not the status, is what makes this recoverable: the client
+      // reads `resource_metadata` from it to find where to re-authenticate. It
+      // reaches the wire through Hono's `c.res` setter, which merges the
+      // headers of the response it replaces, so it is worth pinning.
+      expect(res.headers['www-authenticate']).toContain(
+        `resource_metadata="${oauthConfig.serverBaseUrl}/.well-known/oauth-protected-resource/mcp"`
+      );
+      expect(res.headers['www-authenticate']).toContain(
+        'error="invalid_token"'
+      );
     });
 
     it('revokes the token, so the next call is rejected up front', async () => {

--- a/src/httpMcpServer.test.ts
+++ b/src/httpMcpServer.test.ts
@@ -7,6 +7,9 @@ import type { AddressInfo } from 'node:net';
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/server';
 import { runHttpMcpServer } from './httpMcpServer.js';
+import { createTokenStore } from './auth/tokenStore.js';
+import type { BacklogOAuthConfig } from './auth/backlogOAuthConfig.js';
+import { backlogErrorHandler } from './backlog/backlogErrorHandler.js';
 import {
   wrapServerWithToolRegistry,
   type BacklogMCPServer,
@@ -230,6 +233,97 @@ describe('runHttpMcpServer', () => {
 
       expect(res.status).toBe(400);
       expect(JSON.parse(res.body).error.code).toBe(-32020);
+    });
+  });
+
+  // End to end for #213: an OAuth-authenticated tool call that Backlog rejects
+  // has to reach the client as a transport 401, not as tool output on a 200.
+  describe('a Backlog 401 under OAuth', () => {
+    const oauthConfig: BacklogOAuthConfig = {
+      clientId: 'cid',
+      clientSecret: 'csecret',
+      backlogDomain: 'example.backlog.com',
+      serverBaseUrl: 'https://mcp.example.com',
+    };
+
+    const backlogAuthError = {
+      _name: 'BacklogAuthError',
+      _status: 401,
+      _url: 'https://example.backlog.com/api/v2/users/myself',
+    };
+
+    // A tool shaped like the real ones: the Backlog rejection is funnelled
+    // through backlogErrorHandler and returned as a result, never thrown.
+    const createRejectingServer = (): BacklogMCPServer => {
+      const server = wrapServerWithToolRegistry(
+        new McpServer({ name: 'backlog-test', version: '0.0.0' })
+      );
+      server.registerOnce('get_myself', 'test tool', z.object({}), () => {
+        const { message } = backlogErrorHandler(backlogAuthError);
+        return { content: [{ type: 'text' as const, text: message }] };
+      });
+      return server;
+    };
+
+    const toolsCall = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'get_myself', arguments: {}, _meta: MODERN_ENVELOPE },
+    });
+
+    const startOAuth = async (store: ReturnType<typeof createTokenStore>) =>
+      start({
+        createServer: createRejectingServer,
+        oauthConfig,
+        tokenStore: store,
+      });
+
+    const seed = (store: ReturnType<typeof createTokenStore>) => {
+      store.storeMcpToken('mcp-token', {
+        backlogAccessToken: 'bl-token',
+        clientId: 'c1',
+        expiresAt: Date.now() + 3600_000,
+      });
+      store.cacheVerification(
+        'mcp-token',
+        { token: 'bl-token', clientId: '1', scopes: [], expiresAt: 0 },
+        300_000
+      );
+    };
+
+    const callTool = (port: number) =>
+      send(port, {
+        headers: {
+          authorization: 'Bearer mcp-token',
+          'mcp-method': 'tools/call',
+          'mcp-name': 'get_myself',
+        },
+        body: toolsCall,
+      });
+
+    it('answers 401 with WWW-Authenticate instead of 200', async () => {
+      const store = createTokenStore();
+      seed(store);
+      const port = await startOAuth(store);
+
+      const res = await callTool(port);
+
+      expect(res.status).toBe(401);
+      expect(JSON.parse(res.body).error).toBe('invalid_token');
+    });
+
+    it('revokes the token, so the next call is rejected up front', async () => {
+      const store = createTokenStore();
+      seed(store);
+      const port = await startOAuth(store);
+
+      await callTool(port);
+      const res = await callTool(port);
+
+      expect(res.status).toBe(401);
+      expect(store.getMcpToken('mcp-token')).toBeUndefined();
+      expect(store.getCachedVerification('mcp-token')).toBeUndefined();
     });
   });
 });

--- a/src/httpMcpServer.ts
+++ b/src/httpMcpServer.ts
@@ -13,7 +13,6 @@ import {
 import type { AuthInfo } from '@modelcontextprotocol/server';
 import { createMcpHandler } from '@modelcontextprotocol/server';
 import { Hono } from 'hono';
-import { runWithAccessToken } from './auth/backlogAuthContext.js';
 import type { BacklogOAuthConfig } from './auth/backlogOAuthConfig.js';
 import type { TokenStore } from './auth/tokenStore.js';
 import { logger } from './utils/logger.js';
@@ -111,15 +110,13 @@ export const runHttpMcpServer = async (
     onerror: (err) => logger.error({ err }, 'MCP handler error'),
   });
 
+  // The bearer middleware owns the OAuth request context: it scopes the access
+  // token around this dispatch and converts a Backlog rejection into a 401.
   app.all(mcpPath, async (c) => {
     const authInfo = oauthEnabled ? c.get('authInfo') : undefined;
-    const accessToken = authInfo?.token;
 
     try {
-      const dispatch = () => mcpHandler.fetch(c.req.raw, { authInfo });
-      return accessToken
-        ? await runWithAccessToken(accessToken, dispatch)
-        : await dispatch();
+      return await mcpHandler.fetch(c.req.raw, { authInfo });
     } catch (error) {
       logger.error({ err: error }, 'Error handling MCP request');
       return c.json(

--- a/src/oauthAccessTokenContext.test.ts
+++ b/src/oauthAccessTokenContext.test.ts
@@ -19,7 +19,8 @@ import {
  * Under OAuth, `createOAuthBacklogClientRegistry` resolves the Backlog access
  * token by calling `getCurrentAccessToken()` — an AsyncLocalStorage read — at
  * the moment a tool runs, and throws when it comes back empty. The token is put
- * into that storage by `runWithAccessToken` wrapping `mcpHandler.fetch`.
+ * into that storage by `runWithAccessToken`, which `createBearerAuthMiddleware`
+ * scopes around `next()` — so the context spans the whole dispatch below it.
  *
  * So the whole OAuth transport hinges on the ALS context surviving the SDK's
  * dispatch: request → handler → transport → tool. If the SDK ever resolved


### PR DESCRIPTION
Implements options (1) and (4) from #213.

## Why

`createBearerAuthMiddleware` dispatches a request whose MCP token is live and whose verification is cached (`src/auth/bearerAuthMiddleware.ts:65` on `main`). If the Backlog access token behind that entry has since expired, `backlog-js` throws `BacklogAuthError`, `wrapWithErrorHandling` hands it to `parseBacklogAPIError`, and the client receives `Authentication failed (HTTP 401)` as **tool output over transport `200`**.

Nothing on that path invalidates anything. The entry behind `store.getMcpToken` and the cached verification both survive, so the next call takes the same route and fails the same way. The connector reports itself healthy while every Backlog-backed tool fails, and the client is never handed the one signal it can act on. #213 has the measurements, including the Backlog-side grant behaviour that makes the window reachable in normal use.

## What changed

A Backlog 401 is the authoritative statement that the stored token is no longer usable, so the layer that issued the MCP token now acts on it.

**The request context carries a failure sink.** `runWithAccessToken` (`src/auth/backlogAuthContext.ts`) takes an `onAuthError` callback alongside the token, and `backlogErrorHandler` calls `reportBacklogAuthError()` when it parses a `BacklogAuthError`. Outside that context the call is a no-op, which is what keeps **API-key mode unchanged**: the stdio transport never establishes one, so a 401 there stays an ordinary tool error. No mode flag is threaded through the handlers to achieve that.

**Revocation happens at detection, not after dispatch.** The callback drops the MCP access token and its cached verification immediately (`store.revokeMcpToken`). This matters because `responseMode: 'auto'` upgrades to SSE when a handler emits a message before its result, and such a response resolves before the handler has finished — there would be nothing left to inspect afterwards. Revoking eagerly means the *next* request fails the `getMcpToken` check and is answered with `401` + `WWW-Authenticate` even when the current response could not be rewritten.

**The current response is converted where it still can be.** Once `next()` settles, the middleware checks whether a failure was reported and replaces the result with `401` + `WWW-Authenticate`. On the ordinary JSON path that is the common case, so a client recovers within one round trip instead of two.

**The refresh token is deliberately kept.** A Backlog 401 says the access token is spent, not that the grant is gone. Leaving `mcpRefreshTokens` intact lets a client recover through the refresh grant (`src/auth/oauthRoutes.ts:514`) before falling back to a full re-authorization.

**The OAuth request context moved into the middleware.** `runWithAccessToken` used to wrap the dispatch in `httpMcpServer.ts:121`. Scoping it inside `createBearerAuthMiddleware` puts the token and the failure it can produce under one owner — the layer that can revoke the token and that already computes `resource_metadata` for the three 401s it returns today. `httpMcpServer.ts` loses its auth plumbing and just dispatches.

**(4) The message.** `parseBacklogAPIError` takes an optional `authMode`, defaulting to `apiKey` and the existing wording, so nothing changes for stdio. In OAuth mode, where there is no API key to check, it reads:

```
Authentication failed (HTTP 401). The Backlog access token was rejected.
Re-authenticate with Backlog, or check that your account has permission
for this resource.
```

`backlogErrorHandler` picks the mode from whether a request context is present, the same mechanism `createOAuthBacklogClientRegistry` already uses to resolve the token (`src/utils/backlogClientRegistry.ts:231`).

## Not included

(2) and (3) from #213 — carrying an absolute expiry from `/callback`, and shortening the verification cache. Each narrows one way the window opens, whereas (1) closes the class regardless of how it opened, so they seemed worth deciding separately.

One limitation remains by choice. If a response has already upgraded to SSE, this request still ends as a `200` and only the next one carries the `401`. Forcing `responseMode: 'json'` whenever OAuth is enabled would close that, but it would override an operator's `--http-json-response` choice and drop mid-call notifications for every OAuth deployment. The eager revocation is what keeps the SSE case recoverable.

Also left alone: the cache-miss path where `verifyBacklogToken` itself fails (`src/auth/bearerAuthMiddleware.ts:82`) returns `401` + `WWW-Authenticate` without revoking the entry. That path already recovers — it is row 2 of the table in #213 — and revoking there correctly would mean propagating the HTTP status out of `verifyBacklogToken` so a transient Backlog outage is not mistaken for a rejected token.

## Tests

22 cases added, following the existing co-located layout.

`src/auth/backlogAuthContext.test.ts` (5): the callback fires and the report is recorded; it fires once however often a failure is reported, since one tool call can fan out into several Backlog requests; it is a no-op outside `runWithAccessToken`, which is the API-key case; nothing is reported when no failure occurred; a report does not leak into an enclosing context.

`src/auth/tokenStore.test.ts` (3): `revokeMcpToken` drops the access token and its cached verification, leaves the refresh token usable, and is a no-op for an unknown token.

`src/auth/bearerAuthMiddleware.test.ts` (4): a reported failure turns the tool result into `401` + `WWW-Authenticate`; the token and its cached verification are revoked; the next request on the same token is rejected up front — the case that also covers SSE, where the current response cannot be rewritten; a request that reported nothing is left untouched.

`src/backlog/parseBacklogAPIError.test.ts` (5, new file): both wordings, the `apiKey` default, and the unchanged `BacklogApiError` and unknown-error paths.

`src/backlog/backlogErrorHandler.test.ts` (3, new file): nothing is reported outside a request context, the failure is reported inside one, and a non-authentication failure is left alone.

`src/httpMcpServer.test.ts` (2): end to end over the real transport — an OAuth-authenticated `tools/call` whose tool returns a `BacklogAuthError` result answers `401` instead of `200`, and the second call is rejected before reaching the tool.

## Verified

`pnpm test` (93 files, 507 tests), `pnpm lint`, `pnpm format` and `pnpm build` all pass on Node 24.14.1 / pnpm 10.34.4.
