### PR TITLE
build: install corepack from npm, because node:26 no longer bundles it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM node:26 AS builder
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
+# Node stopped bundling Corepack after Node 24 and the official node images do not
+# install it, so `corepack enable` is `not found` on node:26. `packageManager` in
+# package.json still decides which pnpm is used, hash included.
+RUN npm install -g corepack@latest && corepack enable
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ ENV PATH="$PNPM_HOME:$PATH"
 # Node stopped bundling Corepack after Node 24 and the official node images do not
 # install it, so `corepack enable` is `not found` on node:26. `packageManager` in
 # package.json still decides which pnpm is used, hash included.
-RUN npm install -g corepack@latest && corepack enable
+# Pinned on purpose: release builds run without a layer cache, so a floating tag
+# would make every release depend on whatever corepack shipped that day. Dependabot
+# only tracks `FROM` tags, so bump this by hand.
+RUN npm install -g corepack@0.36.0 && corepack enable
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./


### PR DESCRIPTION
Fixes #219.

`69fc585` moved the Dockerfile from `node:24` to `node:26`, but Corepack is no longer part
of the Node distribution (unbundled after Node 24) and the official `node` images never
installed it themselves — neither
[`26/bookworm/Dockerfile`](https://github.com/nodejs/docker-node/blob/main/26/bookworm/Dockerfile)
nor [`24/bookworm/Dockerfile`](https://github.com/nodejs/docker-node/blob/main/24/bookworm/Dockerfile)
mentions corepack. So `RUN corepack enable` has no binary to run and `docker build` of
`main` fails with `corepack: not found` (exit 127).

This installs corepack from npm. `packageManager` in `package.json` stays the single source
of truth for the pnpm version (hash included), so a floating corepack cannot change which
pnpm gets installed.

No published image is affected: `v0.18.0` predates the `node:26` bump, so it was built on
`node:24`. But `release.yml` is `workflow_dispatch` and runs `docker buildx build ... .`
against the checked-out default branch — it does not build from a release tag — so the next
release would fail on `main`'s Dockerfile. That step runs before `npm publish` and before the
tag is created, so the release would abort without publishing anything half-way.

## Verification

`docker build --target builder .` (linux/arm64) on this branch:

```
Done in 1.5s using pnpm v10.34.4
> backlog-mcp-server@0.18.0 build /app
> tsc && chmod 755 build/index.js
```

Without this change, the same build fails at `[builder 2/7] RUN corepack enable` with
`/bin/sh: 1: corepack: not found`.

