### PR TITLE
feat: add get_issue_attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Tools for managing projects, categories, custom fields, and issue types.
 Tools for managing issues, their comments, and related items like priorities, categories, custom fields, issue types, resolutions, and watching lists.
 
 - `get_issue`: Returns information about a specific issue.
+- `get_issue_attachment`: Downloads one attachment of an issue. Returns it as image or embedded resource content, or as base64 with `format: "base64"`.
 - `get_issues`: Returns list of issues.
 - `count_issues`: Returns count of issues.
 - `add_issue`: Creates a new issue in the specified project.

--- a/src/handlers/builders/composeDynamicToolHandler.test.ts
+++ b/src/handlers/builders/composeDynamicToolHandler.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { composeDynamicToolHandler } from './composeDynamicToolHandler.js';
+import { getCurrentOrganization } from '../../utils/backlogOrganizationContext.js';
+import { DynamicToolDefinition } from '../../types/tool.js';
+
+function toolReturning(
+  handler: DynamicToolDefinition<{ id: z.ZodNumber }>['handler']
+): DynamicToolDefinition<{ id: z.ZodNumber }> {
+  return {
+    name: 'dummy',
+    description: 'dummy',
+    schema: z.object({ id: z.number() }),
+    handler,
+  };
+}
+
+describe('composeDynamicToolHandler', () => {
+  it('passes the result through untouched', async () => {
+    const result = { content: [{ type: 'image', data: 'AA==' }] };
+    const { handler } = composeDynamicToolHandler(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      toolReturning(async () => result as any)
+    );
+
+    await expect(handler({ id: 1 })).resolves.toBe(result);
+  });
+
+  it('runs the handler inside the organization context', async () => {
+    const seen = vi.fn();
+    const { handler } = composeDynamicToolHandler(
+      toolReturning(async () => {
+        seen(getCurrentOrganization());
+        return { content: [] };
+      })
+    );
+
+    await handler({ id: 1, organization: 'second-space' });
+
+    expect(seen).toHaveBeenCalledWith('second-space');
+  });
+
+  it('advertises `organization` only when asked to', () => {
+    const tool = toolReturning(async () => ({ content: [] }));
+
+    expect(Object.keys(composeDynamicToolHandler(tool).schema.shape)).toEqual([
+      'id',
+    ]);
+    expect(
+      Object.keys(
+        composeDynamicToolHandler(tool, { useOrganization: true }).schema.shape
+      )
+    ).toEqual(['id', 'organization']);
+  });
+
+  it('leaves the tool definition unmutated', () => {
+    const tool = toolReturning(async () => ({ content: [] }));
+
+    composeDynamicToolHandler(tool, { useOrganization: true });
+
+    expect(Object.keys(tool.schema.shape)).toEqual(['id']);
+  });
+
+  it('turns a thrown error into an isError result via the error handler', async () => {
+    const errorHandler = vi.fn(() => ({
+      kind: 'error' as const,
+      message: 'handled',
+    }));
+    const { handler } = composeDynamicToolHandler(
+      toolReturning(async () => {
+        throw new Error('boom');
+      }),
+      { errorHandler }
+    );
+
+    await expect(handler({ id: 1 })).resolves.toEqual({
+      isError: true,
+      content: [{ type: 'text', text: 'handled' }],
+    });
+    expect(errorHandler).toHaveBeenCalled();
+  });
+});

--- a/src/handlers/builders/composeDynamicToolHandler.ts
+++ b/src/handlers/builders/composeDynamicToolHandler.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+import { wrapWithErrorHandling } from '../transformers/wrapWithErrorHandling.js';
+import { wrapWithOrganizationContext } from '../transformers/wrapWithOrganizationContext.js';
+import { ErrorLike, isErrorLike } from '../../types/result.js';
+import { DynamicToolDefinition } from '../../types/tool.js';
+
+export type ComposeDynamicOptions = {
+  errorHandler?: (err: unknown) => ErrorLike;
+  useOrganization?: boolean;
+};
+
+type DynamicInput = {
+  organization?: string;
+} & Record<string, unknown>;
+
+/**
+ * Builds the schema and handler a dynamic tool is registered with.
+ *
+ * The counterpart of `composeToolHandler` for tools that produce a
+ * `CallToolResult` themselves. Those cannot go through the whole pipeline:
+ * field picking, the token limit and `wrapWithToolResult` all assume a JSON
+ * value they may reshape, and reshaping is exactly what a tool returning binary
+ * content must not allow — a base64 payload cut at the token limit is a corrupt
+ * file reported as a success.
+ *
+ * The two steps that are not about reshaping still apply, and are why this
+ * exists rather than registering the handler directly:
+ *
+ * - `wrapWithOrganizationContext`, without which a dynamic tool ignores
+ *   `organization` and always talks to the default space;
+ * - `wrapWithErrorHandling`, without which a thrown Backlog error escapes as a
+ *   protocol error rather than an `isError` result, and never reaches the
+ *   handler that reacts to Backlog rejecting a credential.
+ *
+ * As in `composeToolHandler`, the returned schema is a fresh object: the tool
+ * definition is never mutated, because one toolset group is shared across
+ * per-request servers.
+ */
+export function composeDynamicToolHandler(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tool: DynamicToolDefinition<any>,
+  { errorHandler, useOrganization = false }: ComposeDynamicOptions = {}
+) {
+  const schema = useOrganization
+    ? tool.schema.extend({
+        organization: z
+          .string()
+          .optional()
+          .describe(
+            'Optional organization name. Use list_organizations to inspect available organizations.'
+          ),
+      })
+    : tool.schema;
+
+  const handler = wrapWithErrorHandling(
+    wrapWithOrganizationContext(tool.handler),
+    errorHandler
+  );
+
+  return {
+    schema,
+    handler: async (input: DynamicInput) => {
+      const result = await handler(input);
+
+      return isErrorLike(result)
+        ? {
+            isError: true,
+            content: [{ type: 'text' as const, text: result.message }],
+          }
+        : result.data;
+    },
+  };
+}

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -26,6 +26,7 @@ describe('library entry point', () => {
       'allTools',
       'backlogErrorHandler',
       'buildToolSchema',
+      'composeDynamicToolHandler',
       'composeToolHandler',
       'createDescriptionHelper',
       'isErrorLike',

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -15,12 +15,14 @@
 
 export { allTools } from './tools/tools.js';
 export { composeToolHandler } from './handlers/builders/composeToolHandler.js';
+export { composeDynamicToolHandler } from './handlers/builders/composeDynamicToolHandler.js';
 export { createDescriptionHelper } from './createDescriptionHelper.js';
 export { backlogErrorHandler } from './backlog/backlogErrorHandler.js';
 export { buildToolSchema } from './types/tool.js';
 export { isErrorLike } from './types/result.js';
 
 export type { ComposeOptions } from './handlers/builders/composeToolHandler.js';
+export type { ComposeDynamicOptions } from './handlers/builders/composeDynamicToolHandler.js';
 export type { DescriptionHelper } from './createDescriptionHelper.js';
 export type { ToolDefinition, DynamicToolDefinition } from './types/tool.js';
 export type {

--- a/src/registerTools.test.ts
+++ b/src/registerTools.test.ts
@@ -88,7 +88,10 @@ describe('registerTools', () => {
     });
 
     expect(mockServer.registerTool).toHaveBeenCalledTimes(
-      toolsetGroup.toolsets.flatMap((a) => a.tools).length
+      toolsetGroup.toolsets.flatMap((a) => [
+        ...a.tools,
+        ...(a.dynamicTools ?? []),
+      ]).length
     );
   });
 });

--- a/src/registerTools.ts
+++ b/src/registerTools.ts
@@ -1,4 +1,5 @@
 import { backlogErrorHandler } from './backlog/backlogErrorHandler.js';
+import { composeDynamicToolHandler } from './handlers/builders/composeDynamicToolHandler.js';
 import { composeToolHandler } from './handlers/builders/composeToolHandler.js';
 import { MCPOptions } from './types/mcp.js';
 import { DynamicToolDefinition, ToolDefinition } from './types/tool.js';
@@ -46,6 +47,27 @@ export function registerTools(
         maxTokens,
         useOrganization,
       }),
+  });
+
+  // Tools that build their own result, registered from the same toolsets so
+  // that `--enable-toolsets` and the prefix cover them too.
+  registerToolsets({
+    server,
+    toolsetGroup: {
+      toolsets: toolsetGroup.toolsets.map((toolset) => ({
+        name: toolset.name,
+        description: toolset.description,
+        enabled: toolset.enabled,
+        tools: toolset.dynamicTools ?? [],
+      })),
+    },
+    prefix,
+    prepareTool: (tool) =>
+      composeDynamicToolHandler(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tool as DynamicToolDefinition<any>,
+        { errorHandler: backlogErrorHandler, useOrganization }
+      ),
   });
 }
 

--- a/src/tools/getIssueAttachment.test.ts
+++ b/src/tools/getIssueAttachment.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createDescriptionHelper } from '../createDescriptionHelper.js';
+import { getIssueAttachmentTool } from './getIssueAttachment.js';
+
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function streamOf(chunks: number[][]) {
+  let index = 0;
+  const cancel = vi.fn(async () => {});
+  const releaseLock = vi.fn();
+
+  return {
+    body: {
+      getReader: () => ({
+        read: async () =>
+          index < chunks.length
+            ? { done: false, value: Uint8Array.from(chunks[index++]) }
+            : { done: true, value: undefined },
+        cancel,
+        releaseLock,
+      }),
+    },
+    cancel,
+    releaseLock,
+  };
+}
+
+function textOf(content: unknown) {
+  const block = content as { type: string; text: string };
+  expect(block.type).toBe('text');
+  return block.text;
+}
+
+describe('getIssueAttachmentTool', () => {
+  const getIssueAttachment = vi.fn();
+  const backlog = { getIssueAttachment } as unknown as Backlog;
+  const tool = getIssueAttachmentTool(backlog, createDescriptionHelper());
+
+  beforeEach(() => {
+    getIssueAttachment.mockReset();
+  });
+
+  it('returns a verified raster image as MCP image content', async () => {
+    getIssueAttachment.mockResolvedValue({
+      ...streamOf([PNG_MAGIC, [0x01, 0x02]]),
+      filename: 'shot.png',
+      url: 'https://example.backlog.com/api/v2/issues/PROJ-1/attachments/7',
+    });
+
+    const result = await tool.handler({
+      issueKey: 'PROJ-1',
+      attachmentId: 7,
+    });
+
+    expect(getIssueAttachment).toHaveBeenCalledWith('PROJ-1', 7);
+    expect(JSON.parse(textOf(result.content[0]))).toEqual({
+      filename: 'shot.png',
+      contentType: 'image/png',
+      size: 10,
+      attachmentId: 7,
+      issueIdOrKey: 'PROJ-1',
+    });
+    expect(result.content[1]).toEqual({
+      type: 'image',
+      mimeType: 'image/png',
+      data: 'iVBORw0KGgoBAg==',
+    });
+  });
+
+  it('falls back to a resource when the bytes are not the image the name promises', async () => {
+    getIssueAttachment.mockResolvedValue({
+      ...streamOf([[0x25, 0x50, 0x44, 0x46]]),
+      filename: 'not-really.png',
+      url: 'https://example.backlog.com/api/v2/issues/PROJ-1/attachments/8',
+    });
+
+    const result = await tool.handler({
+      issueKey: 'PROJ-1',
+      attachmentId: 8,
+    });
+
+    expect(JSON.parse(textOf(result.content[0])).contentType).toBe(
+      'application/octet-stream'
+    );
+    expect(result.content[1]).toMatchObject({
+      type: 'resource',
+      resource: { mimeType: 'application/octet-stream', blob: 'JVBERg==' },
+    });
+  });
+
+  // `Backlog.parseFileData` slices `Content-Disposition` at the first `''`, so
+  // a header without the RFC 5987 form arrives with its first character gone,
+  // and one with it arrives percent-encoded.
+  it.each([
+    ["UTF-8''%E5%9B%B3%E9%9D%A2.png", '図面.png'],
+    ['ttachment; filename="report.png"', 'report.png'],
+    ['%E5%9B%B3%E9%9D%A2.png', '図面.png'],
+  ])('recovers the filename from %j', async (raw, expected) => {
+    getIssueAttachment.mockResolvedValue({
+      ...streamOf([PNG_MAGIC]),
+      filename: raw,
+      url: 'https://example.backlog.com/api/v2/issues/PROJ-1/attachments/9',
+    });
+
+    const result = await tool.handler({
+      issueKey: 'PROJ-1',
+      attachmentId: 9,
+    });
+
+    expect(JSON.parse(textOf(result.content[0])).filename).toBe(expected);
+  });
+
+  it('falls back to a synthetic name when nothing usable is left', async () => {
+    getIssueAttachment.mockResolvedValue({
+      ...streamOf([[0x00]]),
+      filename: '',
+      url: 'https://example.backlog.com/api/v2/issues/PROJ-1/attachments/11',
+    });
+
+    const result = await tool.handler({
+      issueKey: 'PROJ-1',
+      attachmentId: 11,
+    });
+
+    expect(JSON.parse(textOf(result.content[0])).filename).toBe(
+      'attachment-11'
+    );
+  });
+
+  it("returns filename, contentType, size and base64 content with format 'base64'", async () => {
+    getIssueAttachment.mockResolvedValue({
+      ...streamOf([PNG_MAGIC, [0x01, 0x02]]),
+      filename: 'shot.png',
+      url: 'https://example.backlog.com/api/v2/issues/PROJ-1/attachments/7',
+    });
+
+    const result = await tool.handler({
+      issueKey: 'PROJ-1',
+      attachmentId: 7,
+      format: 'base64',
+    });
+
+    expect(result.content).toHaveLength(1);
+    expect(JSON.parse(textOf(result.content[0]))).toEqual({
+      filename: 'shot.png',
+      contentType: 'image/png',
+      size: 10,
+      content: 'iVBORw0KGgoBAg==',
+    });
+  });
+
+  it('never echoes the download URL, which carries the API key', async () => {
+    getIssueAttachment.mockResolvedValue({
+      ...streamOf([[0x00]]),
+      filename: 'notes.txt',
+      url: 'https://example.backlog.com/api/v2/issues/PROJ-1/attachments/12?apiKey=secret',
+    });
+
+    const result = await tool.handler({
+      issueKey: 'PROJ-1',
+      attachmentId: 12,
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('apiKey');
+    expect(serialized).not.toContain('secret');
+    expect(result.content[1]).toMatchObject({
+      type: 'resource',
+      resource: {
+        uri: 'backlog://attachments/example.backlog.com/issues/PROJ-1/attachments/12/notes.txt',
+      },
+    });
+  });
+
+  it('stops reading and cancels the response once the limit is passed', async () => {
+    const streamed = streamOf([
+      [1, 2, 3],
+      [4, 5, 6],
+    ]);
+    getIssueAttachment.mockResolvedValue({
+      ...streamed,
+      filename: 'big.bin',
+      url: 'https://example.backlog.com/api/v2/issues/PROJ-1/attachments/13',
+    });
+
+    await expect(
+      tool.handler({ issueKey: 'PROJ-1', attachmentId: 13, maxBytes: 4 })
+    ).rejects.toThrow('exceeds the 4-byte response limit');
+    expect(streamed.cancel).toHaveBeenCalled();
+    expect(streamed.releaseLock).toHaveBeenCalled();
+  });
+
+  it('reports a missing issue identifier without calling Backlog', async () => {
+    const result = await tool.handler({ attachmentId: 14 });
+
+    expect(result.isError).toBe(true);
+    expect(getIssueAttachment).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/getIssueAttachment.ts
+++ b/src/tools/getIssueAttachment.ts
@@ -1,0 +1,414 @@
+import { Backlog } from 'backlog-js';
+import { z } from 'zod';
+import { DescriptionHelper } from '../createDescriptionHelper.js';
+import { buildToolSchema, DynamicToolDefinition } from '../types/tool.js';
+import { resolveIdOrKey } from '../utils/resolveIdOrKey.js';
+
+const MEBIBYTE = 1024 * 1024;
+
+/**
+ * Both limits are about what survives the transport, not about what Backlog
+ * allows. Base64 inflates by 4/3, and the MCP SDK caps a single stdio message
+ * at 10 MiB by default, so 7 MiB of raw bytes is the point beyond which a
+ * successful download would still fail to reach the client.
+ */
+const DEFAULT_MAX_BYTES = 5 * MEBIBYTE;
+const MAX_ATTACHMENT_BYTES = 7 * MEBIBYTE;
+
+const MIME_TYPES: Record<string, string> = {
+  '.bmp': 'image/bmp',
+  '.csv': 'text/csv',
+  '.doc': 'application/msword',
+  '.docx':
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.gif': 'image/gif',
+  '.gz': 'application/gzip',
+  '.html': 'text/html',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.json': 'application/json',
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx':
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.svg': 'image/svg+xml',
+  '.tar': 'application/x-tar',
+  '.txt': 'text/plain',
+  '.webp': 'image/webp',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.xml': 'application/xml',
+  '.zip': 'application/zip',
+};
+
+const INLINE_IMAGE_TYPES = new Set([
+  'image/bmp',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+const getIssueAttachmentSchema = buildToolSchema((t) => ({
+  issueId: z
+    .number()
+    .int()
+    .optional()
+    .describe(
+      t(
+        'TOOL_GET_ISSUE_ATTACHMENT_ISSUE_ID',
+        'The numeric ID of the issue (e.g., 12345)'
+      )
+    ),
+  issueKey: z
+    .string()
+    .optional()
+    .describe(
+      t(
+        'TOOL_GET_ISSUE_ATTACHMENT_ISSUE_KEY',
+        "The key of the issue (e.g., 'PROJ-123')"
+      )
+    ),
+  attachmentId: z
+    .number()
+    .int()
+    .positive()
+    .describe(
+      t(
+        'TOOL_GET_ISSUE_ATTACHMENT_ATTACHMENT_ID',
+        "The numeric ID of the attachment. Get it from get_issue (the issue's `attachments` array)."
+      )
+    ),
+  format: z
+    .enum(['auto', 'base64'])
+    .optional()
+    .describe(
+      t(
+        'TOOL_GET_ISSUE_ATTACHMENT_FORMAT',
+        "How to return the file. 'auto' (default) returns a verified raster image as MCP image content and anything else as an embedded resource, so a client can render it. 'base64' returns a single JSON object with the encoded bytes in `content`, for callers that process the file programmatically — note that this puts the whole encoding in the caller's context."
+      )
+    ),
+  maxBytes: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_ATTACHMENT_BYTES)
+    .optional()
+    .describe(
+      t(
+        'TOOL_GET_ISSUE_ATTACHMENT_MAX_BYTES',
+        `Maximum raw attachment size in bytes. Defaults to ${DEFAULT_MAX_BYTES} and cannot exceed ${MAX_ATTACHMENT_BYTES}.`
+      )
+    ),
+}));
+
+type ReadableByteStream = {
+  getReader(): {
+    read(): Promise<{ done: boolean; value?: Uint8Array }>;
+    cancel(reason?: unknown): Promise<void>;
+    releaseLock(): void;
+  };
+};
+
+function isReadableByteStream(body: unknown): body is ReadableByteStream {
+  return (
+    typeof body === 'object' &&
+    body !== null &&
+    'getReader' in body &&
+    typeof body.getReader === 'function'
+  );
+}
+
+/**
+ * Reads the whole body, refusing to buffer more than `maxBytes`.
+ *
+ * The limit is checked per chunk rather than against a `Content-Length`:
+ * `backlog-js` does not surface response headers, and a header would be the
+ * server's claim rather than what actually arrived.
+ */
+async function readBody(
+  body: unknown,
+  maxBytes: number
+): Promise<{ bytes: Uint8Array; size: number }> {
+  if (!isReadableByteStream(body)) {
+    throw new Error('Backlog returned an unsupported attachment body.');
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!(value instanceof Uint8Array)) {
+        throw new Error('Backlog returned a non-binary attachment chunk.');
+      }
+
+      size += value.byteLength;
+      if (size > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // Preserve the size-limit error if cancelling the response also fails.
+        }
+        throw new Error(
+          `Attachment exceeds the ${maxBytes}-byte response limit. Raise maxBytes (up to ${MAX_ATTACHMENT_BYTES}) if the file really is this large.`
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return { bytes, size };
+}
+
+/**
+ * `btoa` over a string built in 32 KiB slices.
+ *
+ * `String.fromCharCode(...bytes)` on a multi-megabyte array overflows the call
+ * stack, and `Buffer` is not available to this module: `src/lib.ts` exposes the
+ * tool layer to consumers that do not run on Node.
+ */
+function toBase64(bytes: Uint8Array): string {
+  const chunks: string[] = [];
+  const chunkSize = 0x8000;
+
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    chunks.push(
+      String.fromCharCode(...bytes.subarray(offset, offset + chunkSize))
+    );
+  }
+
+  return globalThis.btoa(chunks.join(''));
+}
+
+/**
+ * Recovers a usable filename from what `backlog-js` reports.
+ *
+ * `Backlog.parseFileData` takes everything after the first `''` in
+ * `Content-Disposition`. When the header carries no RFC 5987 form, `indexOf`
+ * returns -1 and the result is the header minus its first character; when it
+ * does, the value is left percent-encoded, which is every attachment with a
+ * non-ASCII name. Both are repaired here rather than in the client, so the tool
+ * works against the published `backlog-js`.
+ */
+function normalizeFilename(rawName: string | undefined, attachmentId: number) {
+  const raw = rawName?.trim() ?? '';
+  const contentDispositionMatch =
+    /(?:^|;)\s*filename\*?=\s*(?:[\w-]*'[^']*')?"?([^";]+)"?/i.exec(raw);
+  // A bare `charset'lang'` prefix with no `filename*=` in front of it is what a
+  // client that split the header on the delimiter itself would leave behind.
+  const encodedName = (contentDispositionMatch?.[1] ?? raw).replace(
+    /^[\w-]*'[^']*'/,
+    ''
+  );
+
+  let decodedName = encodedName;
+  try {
+    decodedName = decodeURIComponent(encodedName);
+  } catch {
+    // Keep malformed percent-encoding as provided by Backlog.
+  }
+
+  const basename = decodedName.split(/[/\\]/).pop() ?? decodedName;
+  const cleaned = Array.from(basename)
+    .filter((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint > 0x1f && codePoint !== 0x7f;
+    })
+    .join('')
+    .trim();
+
+  return !cleaned || cleaned === '.' || cleaned === '..'
+    ? `attachment-${attachmentId}`
+    : cleaned;
+}
+
+/**
+ * Derived from the filename, because `backlog-js` discards the response
+ * headers: `File.FileData` is `{ body, url, filename }` and the real
+ * `Content-Type` never reaches this layer.
+ */
+function getContentType(filename: string): string {
+  const extensionIndex = filename.lastIndexOf('.');
+  const extension =
+    extensionIndex >= 0 ? filename.slice(extensionIndex).toLowerCase() : '';
+  return MIME_TYPES[extension] ?? 'application/octet-stream';
+}
+
+function startsWith(bytes: Uint8Array, signature: number[]): boolean {
+  return signature.every((byte, index) => bytes[index] === byte);
+}
+
+/**
+ * Whether the bytes really are the raster format the extension promises.
+ *
+ * A client renders `image` content without checking it, so an attachment named
+ * `.png` that is not a PNG would otherwise become a broken image with no
+ * explanation. Mismatches fall back to an embedded resource.
+ */
+function isExpectedImage(bytes: Uint8Array, contentType: string): boolean {
+  switch (contentType) {
+    case 'image/bmp':
+      return startsWith(bytes, [0x42, 0x4d]);
+    case 'image/gif':
+      return (
+        startsWith(bytes, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]) ||
+        startsWith(bytes, [0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+      );
+    case 'image/jpeg':
+      return startsWith(bytes, [0xff, 0xd8, 0xff]);
+    case 'image/png':
+      return startsWith(
+        bytes,
+        [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+      );
+    case 'image/webp':
+      return (
+        startsWith(bytes, [0x52, 0x49, 0x46, 0x46]) &&
+        bytes[8] === 0x57 &&
+        bytes[9] === 0x45 &&
+        bytes[10] === 0x42 &&
+        bytes[11] === 0x50
+      );
+    default:
+      return false;
+  }
+}
+
+function getSpaceNamespace(sourceUrl: string): string {
+  try {
+    return new URL(sourceUrl).host || 'unknown-space';
+  } catch {
+    return 'unknown-space';
+  }
+}
+
+/**
+ * A synthetic `backlog://` URI, never the URL the download came from.
+ *
+ * In API-key mode `backlog-js` puts the key in the query string, and
+ * `File.FileData.url` carries it verbatim — echoing it into a resource URI
+ * would hand the caller a working credential.
+ */
+function buildResourceUri(
+  sourceUrl: string,
+  issueIdOrKey: string | number,
+  attachmentId: number,
+  filename: string
+): string {
+  const space = encodeURIComponent(getSpaceNamespace(sourceUrl));
+  return `backlog://attachments/${space}/issues/${encodeURIComponent(String(issueIdOrKey))}/attachments/${attachmentId}/${encodeURIComponent(filename)}`;
+}
+
+function errorResult(message: string) {
+  return {
+    isError: true as const,
+    content: [{ type: 'text' as const, text: message }],
+  };
+}
+
+export const getIssueAttachmentTool = (
+  backlog: Backlog,
+  { t }: DescriptionHelper
+): DynamicToolDefinition<ReturnType<typeof getIssueAttachmentSchema>> => {
+  return {
+    name: 'get_issue_attachment',
+    description: t(
+      'TOOL_GET_ISSUE_ATTACHMENT_DESCRIPTION',
+      "Downloads one attachment of an issue. Returns it as MCP image or embedded resource content by default, or as base64 in a JSON object with `format: 'base64'`. Call get_issue first to obtain the attachmentId from the issue's `attachments` array."
+    ),
+    schema: z.object(getIssueAttachmentSchema(t)),
+    handler: async ({ issueId, issueKey, attachmentId, format, maxBytes }) => {
+      const resolved = resolveIdOrKey(
+        'issue',
+        { id: issueId, key: issueKey },
+        t
+      );
+      if (!resolved.ok) {
+        return errorResult(resolved.error.message);
+      }
+
+      const fileData = await backlog.getIssueAttachment(
+        resolved.value,
+        attachmentId
+      );
+      const filename = normalizeFilename(
+        'filename' in fileData ? fileData.filename : undefined,
+        attachmentId
+      );
+      const { bytes, size } = await readBody(
+        fileData.body,
+        maxBytes ?? DEFAULT_MAX_BYTES
+      );
+
+      const declaredType = getContentType(filename);
+      const contentType =
+        INLINE_IMAGE_TYPES.has(declaredType) &&
+        !isExpectedImage(bytes, declaredType)
+          ? 'application/octet-stream'
+          : declaredType;
+      const data = toBase64(bytes);
+
+      if (format === 'base64') {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                { filename, contentType, size, content: data },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      const metadata = {
+        filename,
+        contentType,
+        size,
+        attachmentId,
+        issueIdOrKey: resolved.value,
+      };
+
+      const binaryContent = INLINE_IMAGE_TYPES.has(contentType)
+        ? { type: 'image' as const, data, mimeType: contentType }
+        : {
+            type: 'resource' as const,
+            resource: {
+              uri: buildResourceUri(
+                fileData.url,
+                resolved.value,
+                attachmentId,
+                filename
+              ),
+              blob: data,
+              mimeType: contentType,
+            },
+          };
+
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(metadata, null, 2) },
+          binaryContent,
+        ],
+      };
+    },
+  };
+};

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -16,6 +16,7 @@ import { getCustomFieldsTool } from './getCustomFields.js';
 import { getGitRepositoriesTool } from './getGitRepositories.js';
 import { getGitRepositoryTool } from './getGitRepository.js';
 import { getIssueTool } from './getIssue.js';
+import { getIssueAttachmentTool } from './getIssueAttachment.js';
 import { getIssueCommentsTool } from './getIssueComments.js';
 import { getIssuesTool } from './getIssues.js';
 import { getRelatedIssuesTool } from './getRelatedIssues.js';
@@ -102,6 +103,7 @@ export const allTools = (
         name: 'issue',
         description: 'Tools for managing issues and their comments.',
         enabled: false,
+        dynamicTools: [getIssueAttachmentTool(backlog, helper)],
         tools: [
           getIssueTool(backlog, helper),
           getIssuesTool(backlog, helper),

--- a/src/types/toolsets.ts
+++ b/src/types/toolsets.ts
@@ -8,7 +8,19 @@ type BaseToolset<TTool> = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Toolset = BaseToolset<ToolDefinition<any, any>>;
+export type Toolset = BaseToolset<ToolDefinition<any, any>> & {
+  /**
+   * Tools of this toolset that build their own `CallToolResult`.
+   *
+   * A separate field rather than a member of `tools`, because the two are
+   * registered through different pipelines: a `ToolDefinition` is reshaped by
+   * field picking and the token limit, which a tool returning binary content
+   * must not be. Keeping them in one toolset is what makes `--enable-toolsets`
+   * and the prefix apply to both.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dynamicTools?: DynamicToolDefinition<any>[];
+};
 export type ToolsetGroup = { toolsets: Toolset[] };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Closes #221. Built on #187 by @moritouch — see below and the commit message.

Adds `get_issue_attachment`, wrapping [Get Issue Attachment]. `get_issue` already reports an issue's `attachments` array — id, name and size — and until now nothing could fetch the bytes behind an id.

[Get Issue Attachment]: https://developer.nulab.com/docs/backlog/api/2/get-issue-attachment/

## Output

Two shapes, because there are two callers:

- **`format: "auto"`** (default) — a text block of metadata, plus MCP `image` content for a verified raster and an embedded `resource` otherwise, so a client renders the file.
- **`format: "base64"`** — one JSON object, `filename` / `contentType` / `size` / `content`, for a caller that decodes the file programmatically. Rendered image content cannot be read back out, so a tool that only did the first could not serve this.

## Size limit

Not about what Backlog allows. Base64 inflates by 4/3 and the SDK caps a single stdio message at 10 MiB, so 7 MiB of raw bytes is where a successful download would still fail to reach the client; the default is 5 MiB and `maxBytes` moves it within that ceiling. It is checked per chunk while reading and cancels the response on the way past, rather than buffering everything and then refusing.

## What `backlog-js` leaves to the caller

Verified against 0.19.1 as published; detail in #221.

- **`Backlog.parseFileData` damages the filename.** It takes everything after the first `''` in `Content-Disposition`. Without the RFC 5987 form `indexOf` returns `-1` and the filename becomes the header minus its first character; with it, the value stays percent-encoded — which is every attachment with a non-ASCII name. `normalizeFilename` repairs both, so this works against the published client rather than requiring a fix there first.
- **There is no content type.** `File.NodeFileData` is `{ body, url, filename }`; the response headers are discarded, so `contentType` is derived from the filename extension.
- **`url` is a credential in API-key mode.** The resource URI is therefore synthetic (`backlog://…`), namespaced by the space host, and the download URL is never echoed. The error-message half of the same problem is #222, fixed separately.

An attachment named `.png` whose bytes are not a PNG falls back to a resource: a client renders `image` content without checking it, so a mismatch would otherwise be a broken image with no explanation.

## Registration

A `dynamicTools` field on `Toolset`, registered from `registerTools` through a new `composeDynamicToolHandler`.

A tool that builds its own `CallToolResult` cannot take the regular pipeline — `wrapWithFieldPicking`, `wrapWithTokenLimit` and `wrapWithToolResult` all reshape the value, and a base64 payload cut at the token limit is a corrupt file reported as a success. It still needs the two steps that are not about reshaping: `wrapWithOrganizationContext`, without which the tool ignores `organization` and always talks to the default space, and the error handler, without which a Backlog error escapes as a protocol error instead of an `isError` result. `composeDynamicToolHandler` reuses `wrapWithErrorHandling`, so a dynamic tool takes exactly the error path a regular tool takes.

Keeping the tool in the `issue` toolset rather than a parallel group is what makes `--enable-toolsets` and `--prefix` apply to it. `registerDynamicTools` and `list_organizations` are untouched.

## Relation to the open attachment PRs

#187 is the same tool against the architecture of a month ago. It is 57 commits behind: `docs/` was removed in c359d63, `src/tools/dynamicTools/toolsets.ts` in 06fb2c0, and `TranslationHelper` became `DescriptionHelper` in 4996e56, so about half of it no longer applies. The parts that are hard to get right are kept from it as they are — the filename recovery, the chunked `btoa` that avoids both a stack overflow and `Buffer`, the streaming size guard, the magic-byte check, and the idea of `composeDynamicToolHandler`. I have asked @moritouch on #187 whether they would rather take this forward themselves; **if so I will close this PR.**

#83 and #114 – #117 solve a larger problem — wiki and pull-request attachments, transfer, image optimisation — on `sharp`, Node built-ins and SDK v1. `src/lib.ts` states that nothing reachable from it may touch a Node built-in, and `sharp` is a native dependency, so that family cannot be rebased as it stands.

## Out of scope

Wiki and pull-request attachments, upload, and delete. Each is a separate endpoint, and none is needed to read what `get_issue` already reports.

## Verification

- `oxlint --type-aware --type-check` — clean
- `oxfmt --check src vitest.config.ts` — clean
- `tsc --noEmit` — clean
- `vitest run` — 93 files, 500 tests passed

`src/lib.test.ts` and `src/registerTools.test.ts` are updated for the added export and the added registration path; both would have failed otherwise, which is what they are for.
