### PR TITLE
fix: redact credentials from the URLs in Backlog error messages

### DIFF
--- a/src/backlog/parseBacklogAPIError.test.ts
+++ b/src/backlog/parseBacklogAPIError.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { parseBacklogAPIError } from './parseBacklogAPIError.js';
+
+const API_KEY = 'kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk';
+
+function backlogError(
+  name: string,
+  status: number,
+  url: string,
+  body?: unknown
+) {
+  return { _name: name, _status: status, _url: url, _body: body };
+}
+
+describe('parseBacklogAPIError', () => {
+  // `backlog-js` authenticates an API key by putting it in the query string, so
+  // every error it raises in API-key mode carries the key in `_url`. Tool output
+  // reaches the model and the client's transcript.
+  it.each(['BacklogAuthError', 'BacklogApiError', 'UnexpectedError'])(
+    'redacts the API key from a %s',
+    (name) => {
+      const parsed = parseBacklogAPIError(
+        backlogError(
+          name,
+          name === 'BacklogAuthError' ? 401 : 500,
+          `https://example.backlog.com/api/v2/issues/PROJ-1?apiKey=${API_KEY}`,
+          { errors: [{ message: 'nope', code: 7 }] }
+        )
+      );
+
+      expect(parsed.message).not.toContain(API_KEY);
+      expect(parsed.url).not.toContain(API_KEY);
+      expect(parsed.url).toContain('apiKey=%5BREDACTED%5D');
+    }
+  );
+
+  it('names the failing endpoint in an UnexpectedError, minus the credential', () => {
+    const parsed = parseBacklogAPIError(
+      backlogError(
+        'UnexpectedError',
+        502,
+        `https://example.backlog.com/api/v2/issues/PROJ-1/attachments/7?apiKey=${API_KEY}`
+      )
+    );
+
+    expect(parsed.message).toContain('/api/v2/issues/PROJ-1/attachments/7');
+    expect(parsed.message).not.toContain(API_KEY);
+  });
+
+  it('leaves a URL without credentials untouched', () => {
+    const url =
+      'https://example.backlog.com/api/v2/issues/count?customField_401[0]=2';
+    const parsed = parseBacklogAPIError(
+      backlogError('UnexpectedError', 500, url)
+    );
+
+    expect(parsed.url).toBe(url);
+  });
+
+  it('withholds a URL it cannot parse rather than passing it through', () => {
+    const parsed = parseBacklogAPIError(
+      backlogError('UnexpectedError', 500, `not a url?apiKey=${API_KEY}`)
+    );
+
+    expect(parsed.url).toBe('[unparseable URL redacted]');
+    expect(parsed.message).not.toContain(API_KEY);
+  });
+
+  it('reports a non-Backlog error by its message', () => {
+    expect(parseBacklogAPIError(new Error('boom'))).toEqual({
+      type: 'UnknownError',
+      message: 'boom',
+    });
+  });
+});

--- a/src/backlog/parseBacklogAPIError.ts
+++ b/src/backlog/parseBacklogAPIError.ts
@@ -26,12 +26,60 @@ export type ParsedBacklogAPIError = {
   url?: string;
 };
 
+/**
+ * Query parameters whose value is a credential rather than a request detail.
+ *
+ * `backlog-js` authenticates an API key by putting it in the query string
+ * (`Request.request`: `const query = apiKey ? { apiKey } : {}`), and
+ * `BacklogError._url` is `response.url`, so the key is present verbatim on
+ * every error raised in API-key mode. The others are here because a URL that
+ * reaches this function is not necessarily one this client built.
+ */
+const CREDENTIAL_PARAMS = new Set([
+  'apikey',
+  'access_token',
+  'accesstoken',
+  'refresh_token',
+  'password',
+  'secret',
+  'token',
+]);
+
+/**
+ * Removes credentials from a URL before it is put in a message a client sees.
+ *
+ * Tool output is not a private channel: it reaches the model, the client's
+ * transcript and whatever logs either keeps. An unparseable URL is reported as
+ * absent rather than passed through, because there is no way to tell what it
+ * contains.
+ */
+function redactUrl(rawUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return '[unparseable URL redacted]';
+  }
+
+  let redacted = false;
+  for (const key of [...url.searchParams.keys()]) {
+    if (CREDENTIAL_PARAMS.has(key.toLowerCase())) {
+      url.searchParams.set(key, '[REDACTED]');
+      redacted = true;
+    }
+  }
+
+  // `searchParams.set` percent-encodes the brackets Backlog's own filter
+  // parameters use, so the string is only rebuilt when something changed.
+  return redacted ? url.toString() : rawUrl;
+}
+
 export function parseBacklogAPIError(err: unknown): ParsedBacklogAPIError {
   const e = err as MaybeBacklogErrorObject;
 
   if (e._name && e._status && e._url) {
     const status = e._status;
-    const url = e._url;
+    const url = redactUrl(e._url);
     const code = e._body?.errors?.[0]?.code;
     const message =
       e._body?.errors?.[0]?.message ?? 'An unknown error occurred.';


### PR DESCRIPTION
Closes #222.

`backlog-js` authenticates an API key by putting it in the query string:

```js
// Request.request
const query = apiKey ? { apiKey } : {};
```

`BacklogError._url` is `response.url`, so every error it raises in API-key mode carries the key. `parseBacklogAPIError` puts that URL straight into the message it returns for an `UnexpectedError`, and into the `url` field of all three parsed shapes. `backlogErrorHandler` returns that message as tool output, so the key reaches the model, the client's transcript, and whatever logs either of them keeps.

Reproduced against the published client with a stub `fetch` returning a non-JSON 500 — the branch that produces `UnexpectedError`:

```
Unexpected error (HTTP 500) while accessing
https://example.backlog.com/api/v2/issues/P-1/attachments/7?apiKey=DUMMY_SECRET.
```

`checkStatus` takes that branch whenever the body does not parse as JSON, so any 5xx served as HTML — a proxy error page, a maintenance page, a gateway timeout — is enough.

## Change

Query parameters that name a credential have their value replaced with `[REDACTED]`. The rest of the URL is kept: which endpoint failed is the reason the URL is in the message at all. A URL that does not parse is withheld entirely, since there is no way to tell what it holds. The string is only rebuilt when something was actually redacted, so a URL carrying Backlog's own bracketed filter parameters is returned unchanged rather than re-encoded.

`apiKey` is the one this client produces. The others are there because a URL reaching this function is not necessarily one this client built.

## Scope

- **API-key mode only.** Under OAuth the token is an `Authorization` header and was never in the URL — which is to say this affects the stdio transport every desktop client uses, and not the HTTP one.
- **All tools.** This is the shared error path, not anything specific to one of them.

Found while adding `get_issue_attachment` (#223), but entirely independent of it; that PR does not depend on this one.

## Verification

- `oxlint --type-aware --type-check` — clean
- `oxfmt --check src vitest.config.ts` — clean
- `tsc --noEmit` — clean
- `vitest run` — 92 files, 492 tests passed

`src/backlog/parseBacklogAPIError.ts` had no test file; this adds one, pinning the redaction for each of the three error shapes as well as the pre-existing behaviour it must not change.
