### PR TITLE
fix: match list custom field filters given a single value

### DIFF
--- a/src/backlog/customFields.test.ts
+++ b/src/backlog/customFields.test.ts
@@ -1,10 +1,11 @@
+import { Backlog } from 'backlog-js';
 import {
   customFieldsToPayload,
   customFieldFiltersToPayload,
   type CustomFieldInput,
   type CustomFieldFilterInput,
 } from './customFields.js';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 
 describe('customFieldsToPayload', () => {
   it('returns an empty object when input is undefined', () => {
@@ -136,7 +137,69 @@ describe('customFieldFiltersToPayload', () => {
     ];
     expect(customFieldFiltersToPayload(filters)).toEqual({
       customField_400: 1,
-      'customField_401[]': [2, 3],
+      customField_401: [2, 3],
     });
+  });
+
+  it('does not suffix multi-value list filter keys with []', () => {
+    const filters: CustomFieldFilterInput[] = [
+      { id: 401, type: 'list', value: [2, 3] },
+    ];
+    // `Request.toQueryString` appends the index itself for `customField_` keys,
+    // so a `[]` suffix here produces `customField_401[][0]=…` on the wire.
+    expect(customFieldFiltersToPayload(filters)).not.toHaveProperty(
+      'customField_401[]'
+    );
+  });
+});
+
+// The payload assertions above cannot catch this class of bug on their own: the
+// suite was green while `customField_401[]` was being produced, because the
+// breakage only appears once `Request.toQueryString` expands the array. Pin the
+// actual request URL instead.
+describe('list custom field filters on the wire', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const captureRequestUrl = async (
+    params: Record<string, string | number | number[] | undefined>
+  ): Promise<string> => {
+    let requestUrl = '';
+    vi.stubGlobal('fetch', async (input: string | URL | Request) => {
+      requestUrl = input instanceof Request ? input.url : input.toString();
+      return new Response('0', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const backlog = new Backlog({
+      host: 'example.backlog.com',
+      apiKey: 'dummy',
+    });
+    await backlog.getIssuesCount(params);
+    return decodeURIComponent(requestUrl);
+  };
+
+  it('sends indexed parameters Backlog can match', async () => {
+    const params = customFieldFiltersToPayload([
+      { id: 401, type: 'list', value: [2, 3] },
+    ]);
+
+    const requestUrl = await captureRequestUrl(params);
+
+    expect(requestUrl).toContain('customField_401[0]=2');
+    expect(requestUrl).toContain('customField_401[1]=3');
+    expect(requestUrl).not.toContain('customField_401[][0]');
+  });
+
+  it('sends a bare parameter for a single value', async () => {
+    const params = customFieldFiltersToPayload([
+      { id: 400, type: 'list', value: 1 },
+    ]);
+
+    const requestUrl = await captureRequestUrl(params);
+
+    expect(requestUrl).toContain('customField_400=1');
   });
 });

--- a/src/backlog/customFields.test.ts
+++ b/src/backlog/customFields.test.ts
@@ -135,21 +135,24 @@ describe('customFieldFiltersToPayload', () => {
       { id: 400, type: 'list', value: 1 },
       { id: 401, type: 'list', value: [2, 3] },
     ];
+    // A single value is wrapped, not passed through: Backlog matches a list
+    // custom field only on the indexed parameters an array produces.
     expect(customFieldFiltersToPayload(filters)).toEqual({
-      customField_400: 1,
+      customField_400: [1],
       customField_401: [2, 3],
     });
   });
 
-  it('does not suffix multi-value list filter keys with []', () => {
+  it('does not suffix list filter keys with []', () => {
     const filters: CustomFieldFilterInput[] = [
+      { id: 400, type: 'list', value: 1 },
       { id: 401, type: 'list', value: [2, 3] },
     ];
     // `Request.toQueryString` appends the index itself for `customField_` keys,
     // so a `[]` suffix here produces `customField_401[][0]=…` on the wire.
-    expect(customFieldFiltersToPayload(filters)).not.toHaveProperty(
-      'customField_401[]'
-    );
+    const payload = customFieldFiltersToPayload(filters);
+    expect(payload).not.toHaveProperty('customField_400[]');
+    expect(payload).not.toHaveProperty('customField_401[]');
   });
 });
 
@@ -193,13 +196,16 @@ describe('list custom field filters on the wire', () => {
     expect(requestUrl).not.toContain('customField_401[][0]');
   });
 
-  it('sends a bare parameter for a single value', async () => {
+  it('sends an indexed parameter for a single value too', async () => {
     const params = customFieldFiltersToPayload([
       { id: 400, type: 'list', value: 1 },
     ]);
 
     const requestUrl = await captureRequestUrl(params);
 
-    expect(requestUrl).toContain('customField_400=1');
+    // `customField_400=1` is what a bare value produces, and Backlog does not
+    // match it — it returns every issue rather than rejecting the request.
+    expect(requestUrl).toContain('customField_400[0]=1');
+    expect(requestUrl).not.toContain('customField_400=1');
   });
 });

--- a/src/backlog/customFields.ts
+++ b/src/backlog/customFields.ts
@@ -92,18 +92,19 @@ export function customFieldFiltersToPayload(
         break;
       }
       case 'list': {
-        if (Array.isArray(field.value)) {
-          const values = field.value.filter((value) => Number.isFinite(value));
-          if (values.length > 0) {
-            // Deliberately no `[]` suffix. `Request.toQueryString` already
-            // expands an array under a `customField_` key into indexed
-            // parameters (`customField_1[0]=…`); adding the suffix here makes
-            // it emit `customField_1[][0]=…`, which Backlog does not match, so
-            // the filter is silently ignored and every issue comes back.
-            result[baseKey] = values;
-          }
-        } else if (Number.isFinite(field.value)) {
-          result[baseKey] = field.value;
+        // Always an array, single value included. Backlog matches a list custom
+        // field only on the indexed parameters `customField_1[0]=…`, which
+        // `Request.toQueryString` produces from an array under a `customField_`
+        // key. A bare `customField_1=…` is not matched, and neither is the
+        // `customField_1[][0]=…` that a `[]` suffix on this key would produce.
+        // Neither is rejected either — the filter is silently ignored and every
+        // issue comes back, so the caller cannot tell a filtered query from an
+        // unfiltered one.
+        const values = (
+          Array.isArray(field.value) ? field.value : [field.value]
+        ).filter((value) => Number.isFinite(value));
+        if (values.length > 0) {
+          result[baseKey] = values;
         }
         break;
       }

--- a/src/backlog/customFields.ts
+++ b/src/backlog/customFields.ts
@@ -95,7 +95,12 @@ export function customFieldFiltersToPayload(
         if (Array.isArray(field.value)) {
           const values = field.value.filter((value) => Number.isFinite(value));
           if (values.length > 0) {
-            result[`${baseKey}[]`] = values;
+            // Deliberately no `[]` suffix. `Request.toQueryString` already
+            // expands an array under a `customField_` key into indexed
+            // parameters (`customField_1[0]=…`); adding the suffix here makes
+            // it emit `customField_1[][0]=…`, which Backlog does not match, so
+            // the filter is silently ignored and every issue comes back.
+            result[baseKey] = values;
           }
         } else if (Number.isFinite(field.value)) {
           result[baseKey] = field.value;

--- a/src/tools/countIssues.test.ts
+++ b/src/tools/countIssues.test.ts
@@ -68,7 +68,7 @@ describe('countIssuesTool', () => {
     });
 
     expect(mockBacklog.getIssuesCount).toHaveBeenCalledWith({
-      'customField_11111[]': [7, 8],
+      customField_11111: [7, 8],
     });
   });
 

--- a/src/tools/getIssues.test.ts
+++ b/src/tools/getIssues.test.ts
@@ -133,7 +133,7 @@ describe('getIssuesTool', () => {
     });
 
     expect(mockBacklog.getIssues).toHaveBeenCalledWith({
-      'customField_11111[]': [1, 2, 3],
+      customField_11111: [1, 2, 3],
     });
   });
 

--- a/src/tools/getIssues.test.ts
+++ b/src/tools/getIssues.test.ts
@@ -123,7 +123,7 @@ describe('getIssuesTool', () => {
       customField_67890_min: 10,
       customField_67890_max: 20,
       customField_13579_min: '2024-01-01',
-      customField_24680: 5,
+      customField_24680: [5],
     });
   });
 


### PR DESCRIPTION
## Problem

A `list` type custom field filter is silently ignored unless its value is an array.

`customFieldFiltersToPayload` sends a single value as a bare `customField_<id>=<value>`, and an
array under a `customField_<id>[]` key. Neither is what Backlog matches on:

- `Request.toQueryString` already appends the index for `customField_` keys, so the `[]` suffix
  produces `customField_<id>[][0]=…` on the wire.
- A bare `customField_<id>=…` produces no index at all.

Backlog matches a list custom field **only** on `customField_<id>[0]=…`. The other two shapes are
not rejected — the filter is dropped and every issue comes back, so the caller cannot tell a
filtered query from an unfiltered one.

## Reproduction

Measured against a real Backlog space: one project with 326 issues and a list custom field
(`id=663861`) with several options.

| filter passed | issues returned |
| --- | --- |
| (no filter) | 326 |
| `{ type: 'list', id: 663861, value: 1 }` | 326 ← ignored |
| `{ type: 'list', id: 663861, value: 99 }` (option does not exist) | 326 ← ignored |
| `{ type: 'list', id: 663861, value: [1] }` | 7 |
| `{ type: 'list', id: 663861, value: [1, 2] }` | 117 |
| `{ type: 'list', id: 663861, value: [99] }` | 0 |

The `value: 99` row is the important one: a filter that can match nothing still returns everything,
which is how this stays invisible. `text` and `date` type filters are matched fine as single values.

## Fix

Normalise a `list` filter value to an array in every case, and drop the `[]` suffix so
`toQueryString` produces `customField_<id>[0]=…`.

## Tests

The existing payload assertions could not catch this: the suite was green while
`customField_<id>[]` was being produced, because the breakage only appears once
`toQueryString` expands the array. The added tests stub `fetch` and pin the **request URL**, which
is the level at which this class of bug is visible.

`pnpm test` — 488 passing. `pnpm run lint`, `pnpm run format`, `pnpm run build` all clean.
