### PR TITLE
build: ship only production dependencies in the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm run build
 
+# The runtime needs the production dependencies only. The install above had to
+# pull in the dev toolchain so `pnpm run build` could run, and none of it —
+# typescript, vitest, oxlint, tsx — belongs in a published image. Pruning here
+# rather than reinstalling in the runner keeps pnpm and corepack out of the
+# runtime stage entirely.
+RUN pnpm prune --prod
+
 # Runtime stage
 FROM node:26-slim AS runner
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -479,6 +479,8 @@ MAX_TOKENS=10000
 
 出力**フォーマット**は引き続き `NODE_ENV` が決めます（`production` 以外では `pino-pretty` が利用可能なら人間向けの整形出力に切り替わります）。ログ量を変えたいときは `NODE_ENV` ではなく `LOG_LEVEL` を設定してください。デプロイ先で構造化 JSON のまま保てます。
 
+`pino-pretty` は開発用の依存なので、公開されている npm パッケージにもコンテナイメージにも含まれていません。そのため、これらでは `NODE_ENV` の値に関わらず常に構造化 JSON が出力され、出力を変えられるのは `LOG_LEVEL` だけです。
+
 ```
 LOG_LEVEL=info node build/index.js --transport http
 ```

--- a/README.md
+++ b/README.md
@@ -596,6 +596,8 @@ The server logs to **stderr** (stdout carries the JSON-RPC stream on the stdio t
 
 `NODE_ENV` still selects the output *format*: any value other than `production` switches to human-readable `pino-pretty` output when that package is available. Use `LOG_LEVEL`, not `NODE_ENV`, to change how much is logged, so that a deployment keeps structured JSON:
 
+`pino-pretty` is a development dependency, so neither the published npm package nor the container image carries a copy. In those, logs are structured JSON whatever `NODE_ENV` says, and `LOG_LEVEL` is the only setting that changes the output.
+
 ```
 LOG_LEVEL=info node build/index.js --transport http
 ```


### PR DESCRIPTION
The builder has to install the dev toolchain so `pnpm run build` can run, but the runner
copies that whole `node_modules` across:

```dockerfile
RUN pnpm install --frozen-lockfile        # no --prod: devDependencies included
...
COPY --from=builder /app/node_modules ./node_modules
```

So the published image carries `typescript`, `vitest`, `oxlint`, `oxlint-tsgolint`, `tsx`,
`@vitest/coverage-v8` and the `@types/*` packages. None of them are needed to run the
server, and a container scanner reports every CVE in them against a production image.

Adding `pnpm prune --prod` after the build fixes it in the builder stage, which keeps pnpm
and corepack out of the runtime stage entirely.

## Measured

Built `--target runner` before and after:

|                     | before | after |
| ------------------- | ------ | ----- |
| `/app/node_modules` | 156M   | 26M   |
| top-level packages  | 18     | 9     |
| image               | 594MB  | 415MB |

The server still starts on the pruned tree:

```
$ docker run --rm <after> node build/index.js --version
0.18.0
```

## This also settles `pino-pretty`

`pino-pretty` is a `devDependency`, and `src/utils/logger.ts` says so:

> `pino-pretty` is a development-only dependency, so an installed copy of this package does
> not have it.

That holds for the npm package, but not for the image, which shipped it. So a deployed
container running with `NODE_ENV` set to anything other than `production` emitted
colorized, human-formatted lines that a log collector stores verbatim — the problem #211
describes, reachable in production by accident. #212 made `LOG_LEVEL` independent of
`NODE_ENV`, but the *format* is still `NODE_ENV`'s alone, so there was no way to ask for
JSON back.

With the prune, the image matches the npm package and the question disappears:

```
$ docker run --rm -e NODE_ENV=staging -e LOG_LEVEL=info <after> ...
level=info | {"level":50,"time":...,"msg":"probe"}
```

`prettyLogger` already falls back to `plainLogger` when the transport cannot be resolved
(`src/utils/logger.ts:67`), so an absent `pino-pretty` is a supported state, not a break.
Verified in the built image, including that the default (`NODE_ENV` unset) is still `error`
on plain JSON.

Documented in `README.md` and `README.ja.md`: in the published package and image, `LOG_LEVEL`
is the only setting that changes the output.

If colorized output in a container is wanted as a real feature, the alternative is to move
`pino-pretty` into `dependencies` and add a `LOG_FORMAT` variable instead. That seemed like
the wrong default for a shipped image, but it is the decision behind this PR, so it is worth
naming.

## Verified

`pnpm test` (92 files, 496 tests), `pnpm lint`, `pnpm format` and `pnpm build` all pass, plus
the `docker build --target runner` runs above.
