### PR TITLE
build: let pnpm prune run without a TTY, and build the image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,32 @@ jobs:
 
       - name: 🛠 Build
         run: pnpm run build
+
+  docker:
+    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    name: 🐳 Docker build
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v7
+
+      # release.yml is otherwise the only workflow that builds the image, so a
+      # broken Dockerfile stayed invisible until a release ran — twice now:
+      # corepack disappearing on node:26, and `pnpm prune` aborting without a
+      # TTY. Build it here instead. One native platform is enough to catch that
+      # class of break; the release still builds amd64 and arm64.
+      - name: 🐳 Build image
+        run: docker build --build-arg VERSION=ci -t backlog-mcp-server:ci .
+
+      # Building the image proves it compiles; running it proves the prune left
+      # every production dependency behind. `--export-descriptions` writes the
+      # tool descriptions and exits without reaching Backlog, so a placeholder
+      # domain and key are enough — but the entrypoint does require them.
+      - name: 🚦 Smoke test the image
+        env:
+          BACKLOG_DOMAIN: example.backlog.com
+          BACKLOG_API_KEY: dummy
+        run: |
+          docker run --rm -e BACKLOG_DOMAIN -e BACKLOG_API_KEY \
+            backlog-mcp-server:ci node build/index.js --export-descriptions > /dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
         run: pnpm run build
 
   docker:
-    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     name: 🐳 Docker build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,12 @@ RUN pnpm run build
 # typescript, vitest, oxlint, tsx — belongs in a published image. Pruning here
 # rather than reinstalling in the runner keeps pnpm and corepack out of the
 # runtime stage entirely.
-RUN pnpm prune --prod
+#
+# `CI=true` because pnpm refuses to remove a modules directory it cannot ask
+# about: without a TTY and without that variable it aborts with
+# ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY. The runner sets `CI`, but a
+# `docker buildx build` container does not inherit it.
+RUN CI=true pnpm prune --prod
 
 # Runtime stage
 FROM node:26-slim AS runner


### PR DESCRIPTION
The `Release: patch` run on 2026-08-31 ([33391909015](https://github.com/nulab/backlog-mcp-server/actions/runs/33391909015)) failed:

```
#25 [linux/amd64 builder 8/8] RUN pnpm prune --prod
#25 0.329  ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY  Aborted removal of modules directory due to no TTY
#25 0.329
#25 0.329 If you are running pnpm in CI, set the CI environment variable to "true",
#25 0.329 or set "confirmModulesPurge" to "false".
```

pnpm will not remove a modules directory it cannot ask about. The Actions runner sets `CI`, but a `docker buildx build` container does not inherit it, so inside the image pnpm sees neither a TTY nor the variable and stops. `RUN CI=true pnpm prune --prod` fixes it.

Nothing was published by the failed run — the Docker build fails before `Publish to npm`, `Push version tag` and `Create GitHub release`, and `main` is still on `0.18.0` with no `v0.18.1` tag. Re-running the release after this merges is safe.

## Why CI did not catch it

`ci.yml` runs lint, format, tests and `tsc`. It never builds the image, so `release.yml` was the only thing that exercised the Dockerfile — and it runs after the version bump, at the point where a failure is most expensive. `pnpm prune --prod` landed in #228 three minutes before the release, untested.

This is the second break of exactly this shape; the first was corepack disappearing on `node:26` (#219, fixed by #220).

So this PR also adds a `docker` job that builds the image and runs it once. The smoke test matters as much as the build: `pnpm prune --prod` is precisely the kind of change that produces an image that builds and then dies at startup on a missing dependency. `--export-descriptions` exercises the runtime stage without reaching Backlog, so a placeholder domain and key are enough — though the entrypoint does require them to be set.

One native platform is enough to catch this class of break; the release still builds `linux/amd64` and `linux/arm64`.

## Verified locally

Built from a clean `git archive` context (no `node_modules`, matching what a fresh checkout gives CI):

- `docker build --build-arg VERSION=ci .` — succeeds; the prune step reports removing `typescript`, `vitest` and the rest of the dev toolchain
- `docker run --rm backlog-mcp-server:ci sh -c 'ls node_modules | grep -Ex "typescript|vitest|oxlint|tsx"'` — no matches, so the prune did its job
- `docker run --rm -e BACKLOG_DOMAIN -e BACKLOG_API_KEY backlog-mcp-server:ci node build/index.js --export-descriptions` — exit 0, 25KB of tool descriptions on stdout, nothing on stderr

Without the two env vars that last command exits 1 (`Configure either BACKLOG_ORG_<NAME>_DOMAIN and ...`), which is why the CI step sets them.

## Not addressed here

There is no `.dockerignore`, so `COPY . .` copies whatever the context holds — including a local `node_modules`, which would overwrite the one the image just installed. CI and release both build from a clean checkout so neither is affected today, but it makes a local `docker build` behave differently from CI. Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)