### PR TITLE
build: move the pnpm settings where pnpm reads them

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,0 @@
-minimum-release-age=4320
-# backlog-js is maintained in-house (nulab/backlog-js), so the delay that
-# guards against compromised third-party releases only slows us down here.
-minimum-release-age-exclude[]=backlog-js

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# pnpm reads only auth and registry settings from `.npmrc`; everything else
+# belongs here. `minimum-release-age` happened to work from there in 10.34.4
+# and `minimum-release-age-exclude` did not, which left the delay on with its
+# exemption silently off.
+minimumReleaseAge: 4320
+
+# backlog-js is maintained in-house (nulab/backlog-js), so the delay that
+# guards against compromised third-party releases only slows us down here.
+minimumReleaseAgeExclude:
+  - backlog-js


### PR DESCRIPTION
Closes #235.

`.npmrc` said backlog-js was exempt from the three-day release-age delay. It was not, and bumping it for #187 is how that surfaced.

## What pnpm 10.34.4 actually does

Minimal reproduction — a `package.json` depending on `backlog-js@0.20.1` and nothing else, one config shape per run:

| config | result |
| --- | --- |
| nothing at all | installs |
| `.npmrc`: `minimum-release-age=4320` | **blocked** |
| `.npmrc`: `minimum-release-age=0` | installs |
| `.npmrc`: age + `minimum-release-age-exclude[]=backlog-js` | **blocked** |
| `.npmrc`: age + `minimum-release-age-exclude=backlog-js` | **blocked** |
| `.npmrc`: age + `minimumReleaseAgeExclude[]=backlog-js` | **blocked** |
| `.npmrc`: age + `minimumReleaseAgeExclude=backlog-js` | **blocked** |
| `pnpm-workspace.yaml`: both settings | installs |

The scalar is honoured from `.npmrc`, the list is ignored in every spelling. `pnpm config get` returns a value for all of them, so it reads them and then does not use them.

## Why both settings move, not just the list

pnpm documents that only auth and registry settings come from `.npmrc`; everything else belongs in `pnpm-workspace.yaml`. By that rule `minimum-release-age` should be ignored too — it is not, as the table shows, so today it works on behaviour the documentation does not promise.

That is worth removing while we are here, because of how it would break. If a pnpm upgrade stops reading the scalar, the delay switches off and nothing says so — a guard that stops guarding is silent, unlike the exemption failing, which at least produced an error. Moving both means neither depends on it.

`.npmrc` held nothing else, so the file is removed. No workflow writes to it (the one CI touches is the temporary file `actions/setup-node` generates).

## Verified

Deleting `pnpm-lock.yaml` to force a full re-resolve, since the age check only runs when a version is actually resolved:

- `minimumReleaseAge` + the exclusion → `backlog-js@0.20.1` installs
- `minimumReleaseAge` alone → refused, "The latest release of backlog-js is 0.20.1"

`pnpm install --frozen-lockfile` succeeds either way and the lockfile is unchanged, which is why CI never saw this — the delay only reaches whoever is adding or bumping a dependency locally. 529 tests, `oxlint`, `tsc` and the build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)