### PR TITLE
fix: redact credentials in URLs put into error messages

### DIFF
--- a/src/backlog/parseBacklogAPIError.test.ts
+++ b/src/backlog/parseBacklogAPIError.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseBacklogAPIError,
+  redactCredentialsInUrl,
+} from './parseBacklogAPIError.js';
+
+const SECRET = 'DUMMY_SECRET';
+const BASE = 'https://example.backlog.com/api/v2/issues/P-1/attachments/7';
+
+describe('redactCredentialsInUrl', () => {
+  it('replaces the value of apiKey and keeps the rest of the URL', () => {
+    expect(redactCredentialsInUrl(`${BASE}?apiKey=${SECRET}`)).toBe(
+      `${BASE}?apiKey=REDACTED`
+    );
+  });
+
+  it('keeps non-credential parameters untouched', () => {
+    expect(
+      redactCredentialsInUrl(`${BASE}?count=20&apiKey=${SECRET}&order=asc`)
+    ).toBe(`${BASE}?count=20&apiKey=REDACTED&order=asc`);
+  });
+
+  it('matches credential parameter names case-insensitively', () => {
+    expect(redactCredentialsInUrl(`${BASE}?APIKEY=${SECRET}`)).toBe(
+      `${BASE}?APIKEY=REDACTED`
+    );
+  });
+
+  it.each([
+    'api_key',
+    'access_token',
+    'accessToken',
+    'refresh_token',
+    'token',
+    'client_secret',
+    'password',
+  ])('redacts %s', (name) => {
+    const result = redactCredentialsInUrl(`${BASE}?${name}=${SECRET}`);
+    expect(result).toBe(`${BASE}?${name}=REDACTED`);
+    expect(result).not.toContain(SECRET);
+  });
+
+  it('redacts every occurrence of a repeated credential parameter', () => {
+    expect(
+      redactCredentialsInUrl(`${BASE}?apiKey=${SECRET}&apiKey=${SECRET}2`)
+    ).not.toContain(SECRET);
+  });
+
+  it('leaves a URL without query parameters unchanged', () => {
+    expect(redactCredentialsInUrl(BASE)).toBe(BASE);
+  });
+
+  it('withholds a URL that cannot be parsed', () => {
+    expect(
+      redactCredentialsInUrl(`not a url?apiKey=${SECRET}`)
+    ).toBeUndefined();
+  });
+});
+
+describe('parseBacklogAPIError', () => {
+  it('redacts the API key in the UnexpectedError message and url', () => {
+    const result = parseBacklogAPIError({
+      _name: 'UnexpectedError',
+      _status: 500,
+      _url: `${BASE}?apiKey=${SECRET}`,
+    });
+
+    expect(result.type).toBe('UnexpectedError');
+    expect(result.status).toBe(500);
+    expect(result.url).toBe(`${BASE}?apiKey=REDACTED`);
+    expect(result.message).toBe(
+      `Unexpected error (HTTP 500) while accessing ${BASE}?apiKey=REDACTED.`
+    );
+    expect(result.message).not.toContain(SECRET);
+  });
+
+  it('omits the URL from the UnexpectedError message when it cannot be parsed', () => {
+    const result = parseBacklogAPIError({
+      _name: 'UnexpectedError',
+      _status: 500,
+      _url: `garbage?apiKey=${SECRET}`,
+    });
+
+    expect(result.message).toBe('Unexpected error (HTTP 500).');
+    expect(result.url).toBeUndefined();
+  });
+
+  it('redacts the API key in the url of a BacklogAuthError', () => {
+    const result = parseBacklogAPIError({
+      _name: 'BacklogAuthError',
+      _status: 401,
+      _url: `${BASE}?apiKey=${SECRET}`,
+    });
+
+    expect(result.type).toBe('BacklogAuthError');
+    expect(result.url).toBe(`${BASE}?apiKey=REDACTED`);
+    expect(result.message).toBe(
+      'Authentication failed (HTTP 401). Please check your API key or permissions.'
+    );
+  });
+
+  it('redacts the API key in the url of a BacklogApiError and reports code and message', () => {
+    const result = parseBacklogAPIError({
+      _name: 'BacklogApiError',
+      _status: 400,
+      _url: `${BASE}?apiKey=${SECRET}`,
+      _body: { errors: [{ message: 'Invalid request', code: 7 }] },
+    });
+
+    expect(result).toEqual({
+      type: 'BacklogApiError',
+      message: 'Backlog API error (code: 7, status: 400)\nInvalid request',
+      status: 400,
+      code: 7,
+      url: `${BASE}?apiKey=REDACTED`,
+    });
+  });
+
+  it('falls back to UnknownError for a plain Error', () => {
+    expect(parseBacklogAPIError(new Error('boom'))).toEqual({
+      type: 'UnknownError',
+      message: 'boom',
+    });
+  });
+
+  it('falls back to UnknownError for a BacklogError shape missing a url', () => {
+    expect(
+      parseBacklogAPIError({ _name: 'UnexpectedError', _status: 500 })
+    ).toEqual({
+      type: 'UnknownError',
+      message: 'An unknown error occurred.',
+    });
+  });
+});

--- a/src/backlog/parseBacklogAPIError.ts
+++ b/src/backlog/parseBacklogAPIError.ts
@@ -26,12 +26,53 @@ export type ParsedBacklogAPIError = {
   url?: string;
 };
 
+/**
+ * Query parameter names that carry a credential. Compared case-insensitively.
+ */
+const CREDENTIAL_QUERY_PARAMS = new Set([
+  'apikey',
+  'api_key',
+  'accesstoken',
+  'access_token',
+  'refreshtoken',
+  'refresh_token',
+  'token',
+  'client_secret',
+  'password',
+]);
+
+const REDACTED = 'REDACTED';
+
+/**
+ * Replaces the value of any credential-bearing query parameter, keeping the
+ * rest of the URL so the message still says which endpoint failed.
+ *
+ * Returns undefined for a URL that cannot be parsed: there is no way to tell
+ * what such a string holds, so it is withheld rather than passed through.
+ */
+export function redactCredentialsInUrl(url: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return undefined;
+  }
+
+  for (const name of [...parsed.searchParams.keys()]) {
+    if (CREDENTIAL_QUERY_PARAMS.has(name.toLowerCase())) {
+      parsed.searchParams.set(name, REDACTED);
+    }
+  }
+
+  return parsed.toString();
+}
+
 export function parseBacklogAPIError(err: unknown): ParsedBacklogAPIError {
   const e = err as MaybeBacklogErrorObject;
 
   if (e._name && e._status && e._url) {
     const status = e._status;
-    const url = e._url;
+    const url = redactCredentialsInUrl(e._url);
     const code = e._body?.errors?.[0]?.code;
     const message =
       e._body?.errors?.[0]?.message ?? 'An unknown error occurred.';
@@ -58,7 +99,9 @@ export function parseBacklogAPIError(err: unknown): ParsedBacklogAPIError {
     if (e._name === 'UnexpectedError') {
       return {
         type: 'UnexpectedError',
-        message: `Unexpected error (HTTP ${status}) while accessing ${url}.`,
+        message: url
+          ? `Unexpected error (HTTP ${status}) while accessing ${url}.`
+          : `Unexpected error (HTTP ${status}).`,
         status,
         url,
       };


### PR DESCRIPTION
Closes #222.

## Background

The root cause reported in #222 is already gone: `main` is on `backlog-js@^0.20.1`, which sends the API key as a `Backlog-API-Key` header (`headers["Backlog-API-Key"] = apiKey`) and never puts it in the query string. So `response.url` — and therefore `BacklogError._url` — is clean today.

What is left is the defence in depth the issue's "Fix" section describes, and which the reporter noted when closing #224: nothing in `parseBacklogAPIError` stops a credential-bearing URL from reaching tool output if one ever appears again.

## Change

`src/backlog/parseBacklogAPIError.ts`:

- New `redactCredentialsInUrl()`. It matches `apikey`, `api_key`, `access_token`, `accessToken`, `refresh_token`, `token`, `client_secret` and `password` case-insensitively and replaces only their values with `REDACTED`, keeping the rest of the URL — which endpoint failed is the reason the URL is in the message at all.
- A URL that does not parse is withheld (`undefined`) rather than passed through, since there is no way to tell what it holds. For `UnexpectedError` the message then reads `Unexpected error (HTTP 500).`
- `parseBacklogAPIError` runs both the `message` and the `url` field of all three parsed shapes through it, so the exported `ParsedBacklogAPIError` shape is covered too.

## Tests

`src/backlog/parseBacklogAPIError.test.ts` is new — the file had no tests. 19 cases: the reproduction from the issue (non-JSON 500 taking the `UnexpectedError` branch), each credential parameter name, non-credential parameters left untouched, a repeated parameter, an unparseable URL, and the `UnknownError` fallbacks.

`pnpm test` (547 tests), `pnpm lint`, `pnpm format` and `tsc --noEmit` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)