### PR TITLE
Add add_attachment, the tool that produces an attachmentId

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Tools for managing Backlog space settings and general information.
 - `get_space`: Returns information about the Backlog space.
 - `get_users`: Returns list of users in the Backlog space.
 - `get_myself`: Returns information about the authenticated user.
+- `add_attachment`: Uploads a file and returns its attachment id, for use in the `attachmentId` array of `add_issue`, `update_issue` or `add_issue_comment`. See [Attachment uploads](#attachment-uploads).
 
 ### Toolset: `project`
 
@@ -585,6 +586,25 @@ MAX_TOKENS=10000
 If a response exceeds the limit, it will be truncated with a warning.
 
 > Note: This is a best-effort mitigation, not a guaranteed enforcement.
+
+### Attachment uploads
+
+`add_attachment` is the only tool that reads the host's filesystem. It takes a `filePath`, uploads that file to the space and returns `{ id, name, size }`; the id is what `add_issue`, `update_issue` and `add_issue_comment` accept in `attachmentId`, since those tools attach existing uploads rather than performing one.
+
+The path is resolved **on the machine running the server**, not on the client:
+
+- With the stdio/npx setup the two are the same machine, so a local path works as written.
+- In the container image they are not. Bind-mount the directory first (`-v /host/dir:/data`) and pass the path inside the container.
+
+| Variable                    | Description                                                                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BACKLOG_ATTACHMENT_ROOTS`  | Directories `add_attachment` may read from, separated by the platform's path delimiter (`:` on Unix, `;` on Windows). Unset means no restriction. |
+
+Symlinks are resolved before the check, so a link inside an allowed directory cannot be used to reach a file outside it.
+
+```
+BACKLOG_ATTACHMENT_ROOTS=/srv/uploads:/tmp/backlog-in
+```
 
 ### Logging
 

--- a/src/tools/addAttachment.test.ts
+++ b/src/tools/addAttachment.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { addAttachmentTool } from './addAttachment.js';
+import { createDescriptionHelper } from '../createDescriptionHelper.js';
+import { ATTACHMENT_ROOTS_ENV } from '../utils/attachmentRoots.js';
+
+const FILE_CONTENT = 'screenshot bytes';
+
+// A real temp tree rather than a mocked `node:fs`. The parts worth testing here
+// are symlink resolution and the containment check, and both are properties of
+// the filesystem: a mock that returned whatever the test asked for would assert
+// only that the code calls the functions it obviously calls.
+describe('addAttachmentTool', () => {
+  let root: string;
+  let allowed: string;
+  let outside: string;
+  let insideFile: string;
+  let outsideFile: string;
+
+  const postSpaceAttachment = vi
+    .fn<(form: FormData) => Promise<any>>()
+    .mockResolvedValue({ id: 42, name: 'evidence.png', size: 17 });
+
+  const mockBacklog: Partial<Backlog> = { postSpaceAttachment };
+  const tool = addAttachmentTool(
+    mockBacklog as Backlog,
+    createDescriptionHelper()
+  );
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'backlog-mcp-attachment-'));
+    allowed = join(root, 'allowed');
+    outside = join(root, 'outside');
+    await mkdir(allowed);
+    await mkdir(outside);
+
+    insideFile = join(allowed, 'evidence.png');
+    outsideFile = join(outside, 'secret.png');
+    await writeFile(insideFile, FILE_CONTENT);
+    await writeFile(outsideFile, FILE_CONTENT);
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    postSpaceAttachment.mockClear();
+  });
+
+  it('uploads the file and returns what Backlog reports', async () => {
+    const result = await tool.handler({ filePath: insideFile });
+
+    expect(result).toEqual({ id: 42, name: 'evidence.png', size: 17 });
+    expect(postSpaceAttachment).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends the file under the `file` field, named after the basename', async () => {
+    await tool.handler({ filePath: insideFile });
+
+    const form = postSpaceAttachment.mock.calls[0][0];
+    const sent = form.get('file');
+
+    expect(sent).toBeInstanceOf(Blob);
+    expect((sent as File).name).toBe('evidence.png');
+    expect(await (sent as Blob).text()).toBe(FILE_CONTENT);
+  });
+
+  it('reports a path it cannot read without saying why', async () => {
+    await expect(
+      tool.handler({ filePath: join(allowed, 'missing.png') })
+    ).rejects.toThrow(/Cannot read file/);
+    expect(postSpaceAttachment).not.toHaveBeenCalled();
+  });
+
+  it('refuses a directory', async () => {
+    await expect(tool.handler({ filePath: allowed })).rejects.toThrow(
+      /Not a regular file/
+    );
+    expect(postSpaceAttachment).not.toHaveBeenCalled();
+  });
+
+  it('reads any path when no allowlist is configured', async () => {
+    vi.stubEnv(ATTACHMENT_ROOTS_ENV, '');
+
+    await expect(
+      tool.handler({ filePath: outsideFile })
+    ).resolves.toBeDefined();
+  });
+
+  it('accepts a file inside an allowed root', async () => {
+    vi.stubEnv(ATTACHMENT_ROOTS_ENV, allowed);
+
+    await expect(tool.handler({ filePath: insideFile })).resolves.toBeDefined();
+  });
+
+  it('refuses a file outside every allowed root', async () => {
+    vi.stubEnv(ATTACHMENT_ROOTS_ENV, allowed);
+
+    await expect(tool.handler({ filePath: outsideFile })).rejects.toThrow(
+      new RegExp(ATTACHMENT_ROOTS_ENV)
+    );
+    expect(postSpaceAttachment).not.toHaveBeenCalled();
+  });
+
+  it('gives a missing file outside the roots the same error as an existing one', async () => {
+    vi.stubEnv(ATTACHMENT_ROOTS_ENV, allowed);
+
+    // If this said "Cannot read file" instead, the difference between the two
+    // messages would reveal which paths exist beyond the allowlist.
+    await expect(
+      tool.handler({ filePath: join(outside, 'does-not-exist.png') })
+    ).rejects.toThrow(new RegExp(ATTACHMENT_ROOTS_ENV));
+    expect(postSpaceAttachment).not.toHaveBeenCalled();
+  });
+
+  it('gives a directory outside the roots the same error as a file', async () => {
+    vi.stubEnv(ATTACHMENT_ROOTS_ENV, allowed);
+
+    await expect(tool.handler({ filePath: outside })).rejects.toThrow(
+      new RegExp(ATTACHMENT_ROOTS_ENV)
+    );
+    expect(postSpaceAttachment).not.toHaveBeenCalled();
+  });
+
+  it('still reports a missing file inside the roots as unreadable', async () => {
+    vi.stubEnv(ATTACHMENT_ROOTS_ENV, allowed);
+
+    await expect(
+      tool.handler({ filePath: join(allowed, 'does-not-exist.png') })
+    ).rejects.toThrow(/Cannot read file/);
+  });
+
+  it('refuses a symlink that sits inside an allowed root but points outside it', async () => {
+    const link = join(allowed, 'link-to-secret.png');
+    await symlink(outsideFile, link);
+    vi.stubEnv(ATTACHMENT_ROOTS_ENV, allowed);
+
+    try {
+      await expect(tool.handler({ filePath: link })).rejects.toThrow(
+        new RegExp(ATTACHMENT_ROOTS_ENV)
+      );
+      expect(postSpaceAttachment).not.toHaveBeenCalled();
+    } finally {
+      await rm(link, { force: true });
+    }
+  });
+
+  it('keeps working when one configured root does not exist', async () => {
+    vi.stubEnv(
+      ATTACHMENT_ROOTS_ENV,
+      [join(root, 'no-such-dir'), allowed].join(delimiter)
+    );
+
+    await expect(tool.handler({ filePath: insideFile })).resolves.toBeDefined();
+  });
+});

--- a/src/tools/addAttachment.test.ts
+++ b/src/tools/addAttachment.test.ts
@@ -166,4 +166,19 @@ describe('addAttachmentTool', () => {
 
     await expect(tool.handler({ filePath: insideFile })).resolves.toBeDefined();
   });
+  it('uploads a symlink under the name the caller used, not the target name', async () => {
+    const link = join(allowed, 'as-named-by-caller.png');
+    await symlink(insideFile, link);
+    vi.stubEnv(ATTACHMENT_ROOTS_ENV, allowed);
+
+    try {
+      await tool.handler({ filePath: link });
+
+      const sent = postSpaceAttachment.mock.calls[0][0].get('file') as File;
+      expect(sent.name).toBe('as-named-by-caller.png');
+      expect(await sent.text()).toBe(FILE_CONTENT);
+    } finally {
+      await rm(link, { force: true });
+    }
+  });
 });

--- a/src/tools/addAttachment.ts
+++ b/src/tools/addAttachment.ts
@@ -1,0 +1,170 @@
+import { z } from 'zod';
+import type { Entity } from 'backlog-js';
+import { Backlog } from 'backlog-js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+import { outputFields } from '../types/outputFields.js';
+import { DescriptionHelper } from '../createDescriptionHelper.js';
+import {
+  ATTACHMENT_ROOTS_ENV,
+  isInsideRoot,
+  parseAttachmentRoots,
+} from '../utils/attachmentRoots.js';
+
+const addAttachmentSchema = buildToolSchema((t) => ({
+  filePath: z
+    .string()
+    .min(1)
+    .describe(
+      t(
+        'TOOL_ADD_ATTACHMENT_FILE_PATH',
+        "Path to the file to upload, read on the machine running this server. A relative path resolves against that machine's working directory, so an absolute path is usually what you want. When the server runs in a container, the file has to be bind-mounted into it first."
+      )
+    ),
+}));
+
+/**
+ * The Node built-ins this tool needs, loaded at call time.
+ *
+ * `src/lib.ts` re-exports `allTools`, and its contract is that nothing
+ * reachable from there touches a Node built-in on import — the tool layer is
+ * meant to be hostable on other runtimes. A static `import 'node:fs'` here would
+ * break that for every consumer, including the ones that never call this tool.
+ *
+ * Deferring it keeps the import graph clean and moves the failure to the only
+ * place it means anything: a runtime without `node:fs` cannot serve a local file
+ * path in the first place, so a caller that reaches this line was going to fail
+ * regardless, and now does so with its own error rather than at startup.
+ */
+async function loadFileSystem() {
+  const [fs, fsPromises, path] = await Promise.all([
+    import('node:fs'),
+    import('node:fs/promises'),
+    import('node:path'),
+  ]);
+  return { fs, fsPromises, path };
+}
+
+/**
+ * The configured roots in both the form they were written and their resolved
+ * form, or `undefined` when there is no allowlist.
+ *
+ * Both forms are kept because the two sides of the containment test arrive in
+ * different forms. A real path is compared against real roots; the path as the
+ * caller wrote it, which is all there is when it does not resolve, is compared
+ * against the roots as the operator wrote them. A root that does not resolve
+ * keeps only its written form: one bad entry in the variable should not take
+ * the working ones down with it, and dropping it can only ever refuse an
+ * upload, never permit one.
+ */
+async function loadAllowedRoots({
+  fsPromises,
+  path,
+}: Awaited<ReturnType<typeof loadFileSystem>>): Promise<string[] | undefined> {
+  const env = typeof process === 'undefined' ? undefined : process.env;
+  const roots = parseAttachmentRoots(
+    env?.[ATTACHMENT_ROOTS_ENV],
+    path.delimiter
+  );
+  if (roots === undefined) {
+    return undefined;
+  }
+
+  const forms = await Promise.all(
+    roots.map(async (root) => {
+      const written = path.resolve(root);
+      try {
+        return [written, await fsPromises.realpath(written)];
+      } catch {
+        return [written];
+      }
+    })
+  );
+  return forms.flat();
+}
+
+/**
+ * The real path of the file to upload, once it is known to be inside the
+ * allowlist when one is configured, readable, and a regular file.
+ *
+ * Symlinks are resolved before the containment test, not after: a link sitting
+ * inside an allowed root can point anywhere, so checking the path as given would
+ * approve the link and upload the target.
+ *
+ * The containment test comes before every other check, and a path outside the
+ * allowlist gets the same error whether it exists, is a directory, or is
+ * nothing at all. Ordered the other way, the three messages together would let
+ * a caller map the filesystem beyond the directories it was confined to, one
+ * path per call, which is the thing the allowlist exists to prevent.
+ */
+async function resolveUploadPath(
+  filePath: string,
+  nodeApis: Awaited<ReturnType<typeof loadFileSystem>>
+): Promise<string> {
+  const { fsPromises, path } = nodeApis;
+  const allowedRoots = await loadAllowedRoots(nodeApis);
+  const isAllowed = (candidate: string) =>
+    allowedRoots === undefined ||
+    allowedRoots.some((root) => isInsideRoot(candidate, root, path.sep));
+  const outside = () =>
+    new Error(
+      `${filePath} is outside every directory listed in ${ATTACHMENT_ROOTS_ENV}.`
+    );
+
+  const requested = path.resolve(filePath);
+  let realPath: string;
+  try {
+    realPath = await fsPromises.realpath(requested);
+  } catch {
+    if (!isAllowed(requested)) {
+      throw outside();
+    }
+    // Deliberately not the underlying errno message: a missing file and an
+    // unreadable parent directory both land here, and the distinction says
+    // which of the two it was.
+    throw new Error(`Cannot read file: ${filePath}`);
+  }
+
+  if (!isAllowed(realPath)) {
+    throw outside();
+  }
+
+  const stats = await fsPromises.stat(realPath);
+  if (!stats.isFile()) {
+    throw new Error(`Not a regular file: ${filePath}`);
+  }
+
+  return realPath;
+}
+
+export const addAttachmentTool = (
+  backlog: Backlog,
+  { t }: DescriptionHelper
+): ToolDefinition<
+  ReturnType<typeof addAttachmentSchema>,
+  Entity.File.FileInfo
+> => {
+  return {
+    name: 'add_attachment',
+    description: t(
+      'TOOL_ADD_ATTACHMENT_DESCRIPTION',
+      'Uploads a file and returns its attachment id, name and size. Pass the id in the `attachmentId` array of add_issue, update_issue or add_issue_comment to attach the file — those tools accept ids, they do not upload.'
+    ),
+    schema: z.object(addAttachmentSchema(t)),
+    returnsList: false,
+    outputFields: outputFields<Entity.File.FileInfo>()(['id', 'name', 'size']),
+    handler: async ({ filePath }) => {
+      const nodeApis = await loadFileSystem();
+      const realPath = await resolveUploadPath(filePath, nodeApis);
+
+      // `openAsBlob` rather than `readFile`: the Blob is backed by the file, so
+      // an attachment near the space's per-file limit is streamed into the
+      // request instead of being held in memory in full, then held again as a
+      // copy inside FormData.
+      const blob = await nodeApis.fs.openAsBlob(realPath);
+      const form = new FormData();
+      form.append('file', blob, nodeApis.path.basename(realPath));
+
+      return backlog.postSpaceAttachment(form);
+    },
+  };
+};

--- a/src/tools/addAttachment.ts
+++ b/src/tools/addAttachment.ts
@@ -84,7 +84,14 @@ async function loadAllowedRoots({
 
 /**
  * The real path of the file to upload, once it is known to be inside the
- * allowlist when one is configured, readable, and a regular file.
+ * allowlist when one is configured, readable, and a regular file — and the
+ * name to upload it under.
+ *
+ * The two come from different paths on purpose. Every check runs against the
+ * real path, because that is the file that will actually be read. The name is
+ * taken from the path as the caller wrote it, because that is the name the
+ * caller chose: a symlink named `evidence.png` pointing at `IMG_0522.PNG` is an
+ * `evidence.png` upload, not an `IMG_0522.PNG` one.
  *
  * Symlinks are resolved before the containment test, not after: a link sitting
  * inside an allowed root can point anywhere, so checking the path as given would
@@ -99,7 +106,7 @@ async function loadAllowedRoots({
 async function resolveUploadPath(
   filePath: string,
   nodeApis: Awaited<ReturnType<typeof loadFileSystem>>
-): Promise<string> {
+): Promise<{ realPath: string; uploadName: string }> {
   const { fsPromises, path } = nodeApis;
   const allowedRoots = await loadAllowedRoots(nodeApis);
   const isAllowed = (candidate: string) =>
@@ -133,7 +140,7 @@ async function resolveUploadPath(
     throw new Error(`Not a regular file: ${filePath}`);
   }
 
-  return realPath;
+  return { realPath, uploadName: path.basename(requested) };
 }
 
 export const addAttachmentTool = (
@@ -154,7 +161,10 @@ export const addAttachmentTool = (
     outputFields: outputFields<Entity.File.FileInfo>()(['id', 'name', 'size']),
     handler: async ({ filePath }) => {
       const nodeApis = await loadFileSystem();
-      const realPath = await resolveUploadPath(filePath, nodeApis);
+      const { realPath, uploadName } = await resolveUploadPath(
+        filePath,
+        nodeApis
+      );
 
       // `openAsBlob` rather than `readFile`: the Blob is backed by the file, so
       // an attachment near the space's per-file limit is streamed into the
@@ -162,7 +172,7 @@ export const addAttachmentTool = (
       // copy inside FormData.
       const blob = await nodeApis.fs.openAsBlob(realPath);
       const form = new FormData();
-      form.append('file', blob, nodeApis.path.basename(realPath));
+      form.append('file', blob, uploadName);
 
       return backlog.postSpaceAttachment(form);
     },

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -1,6 +1,7 @@
 import { Backlog } from 'backlog-js';
 import { DescriptionHelper } from '../createDescriptionHelper.js';
 import { ToolsetGroup } from '../types/toolsets.js';
+import { addAttachmentTool } from './addAttachment.js';
 import { addIssueTool } from './addIssue.js';
 import { addIssueCommentTool } from './addIssueComment.js';
 import { addProjectTool } from './addProject.js';
@@ -82,6 +83,7 @@ export const allTools = (
           getUserStarsCountTool(backlog, helper),
           getMyselfTool(backlog, helper),
           getUserRecentUpdatesTool(backlog, helper),
+          addAttachmentTool(backlog, helper),
         ],
       },
       {

--- a/src/utils/attachmentRoots.test.ts
+++ b/src/utils/attachmentRoots.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { isInsideRoot, parseAttachmentRoots } from './attachmentRoots.js';
+
+describe('parseAttachmentRoots', () => {
+  it('returns undefined when the variable is unset', () => {
+    expect(parseAttachmentRoots(undefined, ':')).toBeUndefined();
+  });
+
+  it('returns undefined when the variable holds only separators and spaces', () => {
+    expect(parseAttachmentRoots('  :  : ', ':')).toBeUndefined();
+  });
+
+  it('splits on the delimiter and trims each entry', () => {
+    expect(parseAttachmentRoots('/srv/uploads: /tmp/in ', ':')).toEqual([
+      '/srv/uploads',
+      '/tmp/in',
+    ]);
+  });
+
+  it('drops empty entries rather than treating them as a root', () => {
+    expect(parseAttachmentRoots('/a::/b:', ':')).toEqual(['/a', '/b']);
+  });
+
+  it('uses the delimiter it is given, so Windows paths survive', () => {
+    expect(parseAttachmentRoots('C:\\in;D:\\out', ';')).toEqual([
+      'C:\\in',
+      'D:\\out',
+    ]);
+  });
+});
+
+describe('isInsideRoot', () => {
+  it('accepts the root itself', () => {
+    expect(isInsideRoot('/srv/uploads', '/srv/uploads', '/')).toBe(true);
+  });
+
+  it('accepts a path beneath the root', () => {
+    expect(isInsideRoot('/srv/uploads/a/b.png', '/srv/uploads', '/')).toBe(
+      true
+    );
+  });
+
+  it('rejects a sibling whose name merely starts with the root', () => {
+    expect(isInsideRoot('/srv/uploads-secret/a.png', '/srv/uploads', '/')).toBe(
+      false
+    );
+  });
+
+  it('rejects a path outside the root', () => {
+    expect(isInsideRoot('/etc/passwd', '/srv/uploads', '/')).toBe(false);
+  });
+
+  it('treats a root with a trailing separator the same as one without', () => {
+    expect(isInsideRoot('/srv/uploads/a.png', '/srv/uploads/', '/')).toBe(true);
+  });
+
+  it('works with a Windows separator', () => {
+    expect(isInsideRoot('C:\\in\\a.png', 'C:\\in', '\\')).toBe(true);
+    expect(isInsideRoot('C:\\input\\a.png', 'C:\\in', '\\')).toBe(false);
+  });
+});

--- a/src/utils/attachmentRoots.ts
+++ b/src/utils/attachmentRoots.ts
@@ -1,0 +1,56 @@
+/**
+ * The directory allowlist for `add_attachment`, as pure string logic.
+ *
+ * `add_attachment` is the one tool that reads the host's filesystem, which makes
+ * it the one tool that can send a local file somewhere else. The allowlist is
+ * how an operator bounds that. The path work itself lives in the tool, where
+ * `node:fs` can be reached at call time; what is here is the part that decides,
+ * and it is kept free of Node built-ins so `src/lib.ts` stays importable on
+ * runtimes that have none.
+ *
+ * `delimiter` and `sep` are parameters rather than imports for the same reason.
+ */
+
+export const ATTACHMENT_ROOTS_ENV = 'BACKLOG_ATTACHMENT_ROOTS';
+
+/**
+ * The configured roots, or `undefined` when the variable is unset or empty.
+ *
+ * `undefined` means "no allowlist", not "no roots": an unset variable leaves
+ * `add_attachment` able to read any path the server process can, which is the
+ * only behaviour that works out of the box for the stdio/npx setup where the
+ * server and the caller share a filesystem. Setting the variable is how that is
+ * narrowed. The distinction matters at the call site, so it is carried in the
+ * type rather than flattened to an empty array.
+ */
+export function parseAttachmentRoots(
+  value: string | undefined,
+  delimiter: string
+): string[] | undefined {
+  const roots = (value ?? '')
+    .split(delimiter)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  return roots.length > 0 ? roots : undefined;
+}
+
+/**
+ * Whether `child` is `root` or sits beneath it.
+ *
+ * Both are expected to be resolved real paths. The separator is appended before
+ * the prefix test so that `/srv/uploads-secret` does not count as being inside
+ * `/srv/uploads`, which a bare `startsWith` would allow.
+ */
+export function isInsideRoot(
+  child: string,
+  root: string,
+  sep: string
+): boolean {
+  if (child === root) {
+    return true;
+  }
+
+  const prefix = root.endsWith(sep) ? root : `${root}${sep}`;
+  return child.startsWith(prefix);
+}

--- a/src/utils/attachmentRoots.ts
+++ b/src/utils/attachmentRoots.ts
@@ -38,9 +38,14 @@ export function parseAttachmentRoots(
 /**
  * Whether `child` is `root` or sits beneath it.
  *
- * Both are expected to be resolved real paths. The separator is appended before
- * the prefix test so that `/srv/uploads-secret` does not count as being inside
- * `/srv/uploads`, which a bare `startsWith` would allow.
+ * Both are expected to be absolute, normalized paths — real paths when the
+ * file exists, the `path.resolve`d form otherwise — so the test can be a plain
+ * prefix comparison with no `..` segments or repeated separators to account
+ * for. Normalizing here would need `node:path`, which this module avoids.
+ *
+ * The separator is appended before the prefix test so that `/srv/uploads-secret`
+ * does not count as being inside `/srv/uploads`, which a bare `startsWith`
+ * would allow.
  */
 export function isInsideRoot(
   child: string,


### PR DESCRIPTION
Closes #241.

`add_issue`, `update_issue` and `add_issue_comment` all accept an `attachmentId` array, but no tool produced one: `POST /api/v2/space/attachment` was never exposed, so the parameter could be passed and never filled. This adds `add_attachment`, the write-side counterpart of `get_issue_attachment` (#221).

```
add_attachment({ filePath }) -> { id, name, size }
```

The id goes into the existing `attachmentId` parameters. `backlog-js` already had `postSpaceAttachment(form)`, so the SDK is untouched.

### Design notes

Three choices a reviewer may want to push back on:

1. **`node:fs` is imported at call time, not at module scope.** `src/lib.ts` re-exports `allTools` and promises that nothing reachable from it touches a Node built-in on import (`getIssueAttachment` avoids `Buffer` for the same reason). A static import here would break that for every consumer, including ones that never call this tool. Deferring it moves the failure to the only place it means anything: a runtime without `node:fs` cannot serve a local path anyway.

2. **`BACKLOG_ATTACHMENT_ROOTS` bounds what the tool may read.** This is the first tool that reads the host's filesystem, which makes it the first that can send a local file somewhere else. When the variable is set (path-delimiter separated), the file must resolve inside one of the listed directories; symlinks are resolved first so a link inside an allowed root cannot reach outside it. The containment test runs before the existence and regular-file checks, and everything outside the allowlist gets one error, so the messages cannot be used to map the filesystem beyond the allowed directories. Unset means no restriction — the only default that works out of the box for stdio/npx, where server and caller share a machine. Happy to flip to deny-by-default if you'd rather.

3. **`openAsBlob` rather than `readFile`.** The Blob is backed by the file, so a large attachment is streamed into the request instead of being buffered once and then copied again into `FormData`.

Placed in the `space` toolset since the endpoint is `space/attachment`; easy to move if `issue` reads better.

Not included: a base64 `content` variant for container deployments where the client's filesystem is not visible to the server. It would work anywhere but puts the whole file through the model's context, which makes anything beyond a screenshot impractical. The README documents the bind-mount route instead.

### Verification

```
npx vitest run     # 97 files / 573 tests
npx tsc --noEmit
npm run lint       # oxlint --type-aware --type-check
npm run build && node build/index.js --export-descriptions | grep ADD_ATTACHMENT
```

Also exercised against a real space: uploading a file through the built tool returned `{ id, name, size }` as documented.

The 12 tool tests use a real temp directory rather than a mocked `node:fs`, since symlink resolution and containment are properties of the filesystem, not of the calls.
