### PR TITLE
Add MCP tool for creating project categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Tools for managing issues, their comments, and related items like priorities, ca
 - `remove_related_issue`: Removes the relation between an issue and a related issue.
 - `get_priorities`: Returns list of priorities.
 - `get_categories`: Returns list of categories for a project.
+- `add_category`: Creates a new category for a project.
 - `get_custom_fields`: Returns list of custom fields for a project.
 - `get_issue_types`: Returns list of issue types for a project.
 - `get_resolutions`: Returns list of issue resolutions.

--- a/src/tools/addCategory.test.ts
+++ b/src/tools/addCategory.test.ts
@@ -14,7 +14,10 @@ describe('addCategoryTool', () => {
   };
 
   const mockDescriptionHelper = createDescriptionHelper();
-  const tool = addCategoryTool(mockBacklog as Backlog, mockDescriptionHelper);
+  const tool = addCategoryTool(
+    mockBacklog as Backlog,
+    mockDescriptionHelper
+  );
 
   it('returns created category', async () => {
     const result = await tool.handler({

--- a/src/tools/addCategory.test.ts
+++ b/src/tools/addCategory.test.ts
@@ -1,0 +1,62 @@
+import { addCategoryTool } from './addCategory.js';
+import { vi, describe, it, expect } from 'vitest';
+import type { Backlog } from 'backlog-js';
+import { createDescriptionHelper } from '../createDescriptionHelper.js';
+
+describe('addCategoryTool', () => {
+  const mockBacklog: Partial<Backlog> = {
+    postCategories: vi.fn<() => Promise<any>>().mockResolvedValue({
+      id: 1,
+      projectId: 100,
+      name: 'Support',
+      displayOrder: 0,
+    }),
+  };
+
+  const mockDescriptionHelper = createDescriptionHelper();
+  const tool = addCategoryTool(mockBacklog as Backlog, mockDescriptionHelper);
+
+  it('returns created category', async () => {
+    const result = await tool.handler({
+      projectKey: 'TEST',
+      name: 'Support',
+    });
+
+    if (Array.isArray(result)) {
+      throw new Error('Unexpected array result');
+    }
+    expect(result.id).toEqual(1);
+    expect(result.projectId).toEqual(100);
+    expect(result.name).toEqual('Support');
+  });
+
+  it('calls backlog.postCategories with correct params when using projectKey', async () => {
+    await tool.handler({
+      projectKey: 'TEST',
+      name: 'Support',
+    });
+
+    expect(mockBacklog.postCategories).toHaveBeenCalledWith('TEST', {
+      name: 'Support',
+    });
+  });
+
+  it('calls backlog.postCategories with correct params when using projectId', async () => {
+    await tool.handler({
+      projectId: 100,
+      name: 'Development',
+    });
+
+    expect(mockBacklog.postCategories).toHaveBeenCalledWith(100, {
+      name: 'Development',
+    });
+  });
+
+  it('throws an error if neither projectId nor projectKey is provided', async () => {
+    await expect(
+      tool.handler({
+        name: 'Support',
+      } as any)
+    ).rejects.toThrow(Error);
+  });
+});

--- a/src/tools/addCategory.test.ts
+++ b/src/tools/addCategory.test.ts
@@ -14,10 +14,7 @@ describe('addCategoryTool', () => {
   };
 
   const mockDescriptionHelper = createDescriptionHelper();
-  const tool = addCategoryTool(
-    mockBacklog as Backlog,
-    mockDescriptionHelper
-  );
+  const tool = addCategoryTool(mockBacklog as Backlog, mockDescriptionHelper);
 
   it('returns created category', async () => {
     const result = await tool.handler({

--- a/src/tools/addCategory.test.ts
+++ b/src/tools/addCategory.test.ts
@@ -56,10 +56,8 @@ describe('addCategoryTool', () => {
   });
 
   it('throws an error if neither projectId nor projectKey is provided', async () => {
-    await expect(
-      tool.handler({
-        name: 'Support',
-      } as any)
-    ).rejects.toThrow(Error);
+    const params = { name: 'Support' };
+
+    await expect(tool.handler(params as any)).rejects.toThrow(Error);
   });
 });

--- a/src/tools/addCategory.ts
+++ b/src/tools/addCategory.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import type { Entity } from 'backlog-js';
+import { Backlog } from 'backlog-js';
+import { buildToolSchema, ToolDefinition } from '../types/tool.js';
+import { outputFields } from '../types/outputFields.js';
+import { DescriptionHelper } from '../createDescriptionHelper.js';
+import { resolveIdOrKey } from '../utils/resolveIdOrKey.js';
+
+const addCategorySchema = buildToolSchema((t) => ({
+  projectId: z
+    .number()
+    .optional()
+    .describe(
+      t(
+        'TOOL_ADD_CATEGORY_PROJECT_ID',
+        'The numeric ID of the project (e.g., 12345)'
+      )
+    ),
+  projectKey: z
+    .string()
+    .optional()
+    .describe(
+      t('TOOL_ADD_CATEGORY_PROJECT_KEY', "The key of the project (e.g., 'PROJECT')")
+    ),
+  name: z
+    .string()
+    .describe(t('TOOL_ADD_CATEGORY_NAME', 'The name of the category')),
+}));
+
+export const addCategoryTool = (
+  backlog: Backlog,
+  { t }: DescriptionHelper
+): ToolDefinition<ReturnType<typeof addCategorySchema>, Entity.Project.Category> => {
+  return {
+    name: 'add_category',
+    description: t(
+      'TOOL_ADD_CATEGORY_DESCRIPTION',
+      'Creates a new category for a project'
+    ),
+    schema: z.object(addCategorySchema(t)),
+    importantFields: ['id', 'projectId', 'name'],
+    returnsList: false,
+    outputFields: outputFields<Entity.Project.Category>()([
+      'id',
+      'projectId',
+      'name',
+      'displayOrder',
+    ]),
+    handler: async ({ projectId, projectKey, ...params }) => {
+      const result = resolveIdOrKey(
+        'project',
+        { id: projectId, key: projectKey },
+        t
+      );
+      if (!result.ok) {
+        throw result.error;
+      }
+      return backlog.postCategories(result.value, params);
+    },
+  };
+};

--- a/src/tools/addCategory.ts
+++ b/src/tools/addCategory.ts
@@ -20,7 +20,10 @@ const addCategorySchema = buildToolSchema((t) => ({
     .string()
     .optional()
     .describe(
-      t('TOOL_ADD_CATEGORY_PROJECT_KEY', "The key of the project (e.g., 'PROJECT')")
+      t(
+        'TOOL_ADD_CATEGORY_PROJECT_KEY',
+        "The key of the project (e.g., 'PROJECT')"
+      )
     ),
   name: z
     .string()
@@ -30,7 +33,10 @@ const addCategorySchema = buildToolSchema((t) => ({
 export const addCategoryTool = (
   backlog: Backlog,
   { t }: DescriptionHelper
-): ToolDefinition<ReturnType<typeof addCategorySchema>, Entity.Project.Category> => {
+): ToolDefinition<
+  ReturnType<typeof addCategorySchema>,
+  Entity.Project.Category
+> => {
   return {
     name: 'add_category',
     description: t(

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -10,6 +10,7 @@ import { addWikiTool } from './addWiki.js';
 import { updateWikiTool } from './updateWiki.js';
 import { countIssuesTool } from './countIssues.js';
 import { deleteIssueTool } from './deleteIssue.js';
+import { addCategoryTool } from './addCategory.js';
 import { getCategoriesTool } from './getCategories.js';
 import { getCustomFieldsTool } from './getCustomFields.js';
 import { getGitRepositoriesTool } from './getGitRepositories.js';
@@ -117,6 +118,7 @@ export const allTools = (
           removeRelatedIssueTool(backlog, helper),
           getPrioritiesTool(backlog, helper),
           getCategoriesTool(backlog, helper),
+          addCategoryTool(backlog, helper),
           getCustomFieldsTool(backlog, helper),
           getIssueTypesTool(backlog, helper),
           getResolutionsTool(backlog, helper),


### PR DESCRIPTION
## Summary

Adds an `add_category` MCP tool for creating project categories through the existing Backlog API.

This follows the existing category and version/milestone tool patterns and keeps the scope intentionally small.

## Changes

- add `src/tools/addCategory.ts`
- register `add_category` alongside `get_categories`
- add unit tests for project key / project ID handling and missing project input
- use `backlog-js` `postCategories(projectIdOrKey, { name })`

## Scope / safety

This PR only adds category creation. It does not add `update_category` or `delete_category`.

Closes #244