### PR TITLE
test: clear mock call history between tests

### DIFF
--- a/src/auth/bearerAuthMiddleware.test.ts
+++ b/src/auth/bearerAuthMiddleware.test.ts
@@ -26,7 +26,6 @@ describe('createBearerAuthMiddleware', () => {
   let app: Hono;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     store = createTokenStore();
     app = new Hono();
     app.use('/mcp', createBearerAuthMiddleware(store, config, '/mcp'));

--- a/src/auth/oauthRoutes.test.ts
+++ b/src/auth/oauthRoutes.test.ts
@@ -38,7 +38,6 @@ describe('createOAuthRoutes', () => {
   let app: ReturnType<typeof createOAuthRoutes>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
     store = createTokenStore();
     app = createOAuthRoutes(config, store, '/mcp');
   });

--- a/src/createBacklogMcpServer.test.ts
+++ b/src/createBacklogMcpServer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { Backlog } from 'backlog-js';
 import { McpServer } from '@modelcontextprotocol/server';
 import { createDescriptionHelper } from './createDescriptionHelper.js';
@@ -48,10 +48,6 @@ describe('createBacklogMcpServer', () => {
     enabledToolsets: ['all'],
     mcpOption,
   };
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
 
   it('returns a server wrapped with tool registry', () => {
     const server = createBacklogMcpServer(baseConfig);

--- a/src/registerTools.test.ts
+++ b/src/registerTools.test.ts
@@ -2,7 +2,7 @@ import { registerTools } from './registerTools';
 import { McpServer } from '@modelcontextprotocol/server';
 import { Backlog } from 'backlog-js';
 import { DescriptionHelper } from './createDescriptionHelper';
-import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
 import { allTools } from './tools/tools';
 import { buildToolsetGroup } from './utils/toolsetUtils.js';
 import { wrapServerWithToolRegistry } from './utils/wrapServerWithToolRegistry.js';
@@ -41,10 +41,6 @@ describe('registerTools', () => {
   if (issueToolSet == null) {
     throw new Error(`Toolset "issue" not found in allTools. Check test setup.`);
   }
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
 
   it('registers tools from enabled toolsets only', () => {
     const mockServer = wrapServerWithToolRegistry({

--- a/src/tools/updateIssueComment.test.ts
+++ b/src/tools/updateIssueComment.test.ts
@@ -1,5 +1,5 @@
 import { updateIssueCommentTool } from './updateIssueComment.js';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi, describe, it, expect } from 'vitest';
 import type { Backlog } from 'backlog-js';
 import { createDescriptionHelper } from '../createDescriptionHelper.js';
 
@@ -32,10 +32,6 @@ describe('updateIssueCommentTool', () => {
     mockBacklog as Backlog,
     mockDescriptionHelper
   );
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
 
   it('returns updated comment', async () => {
     const result = await tool.handler({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    clearMocks: true,
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Why

The tool tests build one mock `Backlog` at `describe` scope and reuse it across cases. Nothing clears the call history between tests (`vitest.config.ts` sets no `clearMocks`, and there is no setup file), so a call made by an earlier test is still on record when a later test asserts `toHaveBeenCalledWith`.

That makes the "passes the project key through" assertions unfalsifiable. Deleting the handler call from such a test leaves it green, satisfied by the *previous* test's call:

```diff
   it('calls backlog.getCategories with correct params when using project key', async () => {
-    await tool.handler({ projectKey: 'TEST' });
+    // handler intentionally NOT called

     expect(mockBacklog.getCategories).toHaveBeenCalledWith('TEST');
   });
```

Before this change that still reported `4 passed`. After it, the case fails as it should.

## Changes

**`clearMocks: true` in `vitest.config.ts`.** It calls `mockClear()` before each test: call history goes, the `mockResolvedValue` implementations set at `describe` scope stay (that would be `mockReset`), so no test needs rewriting.

**Removed the five `vi.clearAllMocks()` hooks it makes redundant.** Three of them (`registerTools`, `createBacklogMcpServer`, `updateIssueComment`) held nothing else, so the whole `beforeEach` goes; in `bearerAuthMiddleware` and `oauthRoutes` the hook keeps its real setup and only the clear line goes.

Deliberately kept:

- the five `vi.restoreAllMocks()` calls - they undo `vi.spyOn`, which `clearMocks` does not touch
- `getIssueAttachment.mockReset()` - `mockReset` also drops the implementation, so each case starts without the previous one's `mockResolvedValue`

## Verification

Full suite passes unchanged: `95 files, 551 tests`. `format`, `lint` and `build` clean.

Test infrastructure only - no `src/` behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)