### PR TITLE
Answer a revoked grant with invalid_grant, not 503

### DIFF
--- a/src/auth/backlogOAuthClient.test.ts
+++ b/src/auth/backlogOAuthClient.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+  BacklogTokenError,
   buildBacklogAuthorizationUrl,
   exchangeBacklogCode,
   refreshBacklogToken,
@@ -109,6 +110,65 @@ describe('refreshBacklogToken', () => {
       'Backlog token refresh failed (401)'
     );
   });
+
+  // The status is what tells a revoked grant from a Backlog that is merely
+  // down, and `/token` answers `invalid_grant` or `server_error` on it. Carried
+  // in the message alone the caller would have to parse prose to decide.
+  it('carries the upstream status on a rejection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{"error":"invalid_grant"}', { status: 400 })
+    );
+
+    await expect(refreshBacklogToken(config, 'revoked')).rejects.toMatchObject({
+      name: 'BacklogTokenError',
+      status: 400,
+    });
+  });
+
+  it('leaves the status absent when Backlog cannot be reached', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('fetch failed')
+    );
+
+    const err = await refreshBacklogToken(config, 'rt').catch(
+      (e: unknown) => e
+    );
+
+    expect(err).toBeInstanceOf(BacklogTokenError);
+    expect((err as BacklogTokenError).status).toBeUndefined();
+  });
+
+  // The status cannot separate these two, and they ask `/token` for opposite
+  // answers: a dead grant means re-authorize, a rejected client secret is the
+  // operator's problem and re-authorizing would fail the same way.
+  it.each([
+    ['invalid_grant', 400],
+    ['invalid_client', 401],
+  ])('reads %s out of the response body', async (code, status) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: code }), { status })
+    );
+
+    await expect(refreshBacklogToken(config, 'rt')).rejects.toMatchObject({
+      status,
+      errorCode: code,
+    });
+  });
+
+  // A proxy or a WAF can answer the token endpoint with HTML. The status and
+  // the raw text are already in the message, so there is nothing to recover.
+  it('leaves the error code absent when the body is not an OAuth error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('<html>Gateway Timeout</html>', { status: 504 })
+    );
+
+    const err = await refreshBacklogToken(config, 'rt').catch(
+      (e: unknown) => e
+    );
+
+    expect((err as BacklogTokenError).status).toBe(504);
+    expect((err as BacklogTokenError).errorCode).toBeUndefined();
+  });
 });
 
 describe('verifyBacklogToken', () => {
@@ -141,5 +201,28 @@ describe('verifyBacklogToken', () => {
     await expect(
       verifyBacklogToken('example.backlog.com', 'bad-token')
     ).rejects.toThrow('Backlog token verification failed (401)');
+  });
+
+  it('carries the upstream status on a rejection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Unauthorized', { status: 401 })
+    );
+
+    await expect(
+      verifyBacklogToken('example.backlog.com', 'bad-token')
+    ).rejects.toMatchObject({ name: 'BacklogTokenError', status: 401 });
+  });
+
+  it('leaves the status absent when Backlog cannot be reached', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new TypeError('fetch failed')
+    );
+
+    const err = await verifyBacklogToken('example.backlog.com', 'token').catch(
+      (e: unknown) => e
+    );
+
+    expect(err).toBeInstanceOf(BacklogTokenError);
+    expect((err as BacklogTokenError).status).toBeUndefined();
   });
 });

--- a/src/auth/backlogOAuthClient.ts
+++ b/src/auth/backlogOAuthClient.ts
@@ -4,6 +4,60 @@
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 import type { BacklogTokenData } from './tokenStore.js';
 
+/**
+ * A failed Backlog token call, carrying what the caller needs to decide what to
+ * tell the client.
+ *
+ * Whether Backlog rejected the credential or could not be reached decides
+ * whether the client should authorize again or back off and retry. Folded into
+ * a message string the two are the same exception, and the caller is left
+ * parsing prose to tell them apart.
+ *
+ * `status` is absent when the request never produced a response — DNS failure,
+ * refused connection, timeout — which is unambiguously the retry case, so "no
+ * status" reads as "not a rejection" without having to guess.
+ *
+ * `errorCode` is the OAuth error code from the response body, which is where
+ * RFC 6749 §5.2 puts the reason. It is the more precise of the two: the status
+ * alone cannot separate `invalid_grant` from `invalid_client`, and those ask
+ * the caller for opposite behaviour. Absent when the body is not an OAuth error
+ * object, which is every response outside the token endpoint.
+ */
+export class BacklogTokenError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly errorCode?: string
+  ) {
+    super(message);
+    this.name = 'BacklogTokenError';
+  }
+}
+
+/**
+ * The `error` field of an RFC 6749 §5.2 error response, if the body is one.
+ *
+ * Best effort by design: a proxy or a WAF can answer the token endpoint with
+ * HTML, and a body that is not an OAuth error object simply carries no code.
+ */
+function readOAuthErrorCode(body: string): string | undefined {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'error' in parsed &&
+      typeof parsed.error === 'string'
+    ) {
+      return parsed.error;
+    }
+  } catch {
+    // Not JSON. Nothing to read, and nothing worth reporting either: the
+    // status and the raw text are already in the message.
+  }
+  return undefined;
+}
+
 export function buildBacklogAuthorizationUrl(
   config: BacklogOAuthConfig,
   redirectUri: string,
@@ -61,19 +115,28 @@ export async function refreshBacklogToken(
     refresh_token: refreshToken,
   });
 
-  const response = await fetch(
-    `https://${config.backlogDomain}/api/v2/oauth2/token`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: params.toString(),
-    }
-  );
+  let response: Response;
+  try {
+    response = await fetch(
+      `https://${config.backlogDomain}/api/v2/oauth2/token`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params.toString(),
+      }
+    );
+  } catch (err) {
+    throw new BacklogTokenError(
+      `Could not reach Backlog to refresh the token: ${String(err)}`
+    );
+  }
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(
-      `Backlog token refresh failed (${response.status}): ${text}`
+    throw new BacklogTokenError(
+      `Backlog token refresh failed (${response.status}): ${text}`,
+      response.status,
+      readOAuthErrorCode(text)
     );
   }
 
@@ -84,12 +147,22 @@ export async function verifyBacklogToken(
   domain: string,
   accessToken: string
 ): Promise<{ id: number; userId: string; name: string }> {
-  const response = await fetch(`https://${domain}/api/v2/users/myself`, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
+  let response: Response;
+  try {
+    response = await fetch(`https://${domain}/api/v2/users/myself`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+  } catch (err) {
+    throw new BacklogTokenError(
+      `Could not reach Backlog to verify the token: ${String(err)}`
+    );
+  }
 
   if (!response.ok) {
-    throw new Error(`Backlog token verification failed (${response.status})`);
+    throw new BacklogTokenError(
+      `Backlog token verification failed (${response.status})`,
+      response.status
+    );
   }
 
   return await response.json();

--- a/src/auth/bearerAuthMiddleware.test.ts
+++ b/src/auth/bearerAuthMiddleware.test.ts
@@ -8,11 +8,17 @@ import { reportBacklogAuthError } from './backlogAuthContext.js';
 import { createTokenStore } from './tokenStore.js';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 
-vi.mock('./backlogOAuthClient.js', () => ({
+// `BacklogTokenError` is the real class because the middleware branches on
+// `instanceof`; `verifyBacklogToken` is the only function this file needs, and
+// leaving the rest out keeps the network unreachable from here.
+vi.mock('./backlogOAuthClient.js', async (importOriginal) => ({
+  BacklogTokenError: (
+    await importOriginal<typeof import('./backlogOAuthClient.js')>()
+  ).BacklogTokenError,
   verifyBacklogToken: vi.fn(),
 }));
 
-import { verifyBacklogToken } from './backlogOAuthClient.js';
+import { BacklogTokenError, verifyBacklogToken } from './backlogOAuthClient.js';
 
 const config: BacklogOAuthConfig = {
   clientId: 'cid',
@@ -102,9 +108,75 @@ describe('createBearerAuthMiddleware', () => {
     );
   });
 
-  it('returns 401 when Backlog token verification fails', async () => {
+  it('returns 401 when Backlog rejects the token', async () => {
     store.storeMcpToken('mcp-token-3', {
       backlogAccessToken: 'bl-bad-token',
+      clientId: 'c1',
+      expiresAt: Date.now() + 3600_000,
+    });
+
+    vi.mocked(verifyBacklogToken).mockRejectedValue(
+      new BacklogTokenError('Backlog token verification failed (401)', 401)
+    );
+
+    const res = await app.request('/mcp', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer mcp-token-3' },
+    });
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('invalid_token');
+  });
+
+  it('revokes the MCP token when Backlog rejects it', async () => {
+    store.storeMcpToken('mcp-token-4', {
+      backlogAccessToken: 'bl-bad-token',
+      clientId: 'c1',
+      expiresAt: Date.now() + 3600_000,
+    });
+
+    vi.mocked(verifyBacklogToken).mockRejectedValue(
+      new BacklogTokenError('Backlog token verification failed (401)', 401)
+    );
+
+    await app.request('/mcp', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer mcp-token-4' },
+    });
+
+    expect(store.getMcpToken('mcp-token-4')).toBeUndefined();
+  });
+
+  // A Backlog outage is not a rejected token. Answered with 401 it would send
+  // every connected client through a fresh authorization whose result would
+  // fail verification just the same, and cost them their stored token on the
+  // way out.
+  it('returns 503 and keeps the token when Backlog cannot be reached', async () => {
+    store.storeMcpToken('mcp-token-5', {
+      backlogAccessToken: 'bl-token-5',
+      clientId: 'c1',
+      expiresAt: Date.now() + 3600_000,
+    });
+
+    vi.mocked(verifyBacklogToken).mockRejectedValue(
+      new BacklogTokenError('Could not reach Backlog to verify the token')
+    );
+
+    const res = await app.request('/mcp', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer mcp-token-5' },
+    });
+
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toBe('temporarily_unavailable');
+    expect(res.headers.get('retry-after')).toBe('30');
+    expect(store.getMcpToken('mcp-token-5')).toBeDefined();
+  });
+
+  // Anything that is not a `BacklogTokenError` carries no status at all, so it
+  // cannot be read as a rejection either.
+  it('returns 503 for a verification failure of unknown shape', async () => {
+    store.storeMcpToken('mcp-token-6', {
+      backlogAccessToken: 'bl-token-6',
       clientId: 'c1',
       expiresAt: Date.now() + 3600_000,
     });
@@ -113,9 +185,11 @@ describe('createBearerAuthMiddleware', () => {
 
     const res = await app.request('/mcp', {
       method: 'POST',
-      headers: { Authorization: 'Bearer mcp-token-3' },
+      headers: { Authorization: 'Bearer mcp-token-6' },
     });
-    expect(res.status).toBe(401);
+
+    expect(res.status).toBe(503);
+    expect(store.getMcpToken('mcp-token-6')).toBeDefined();
   });
 
   // Regression for a Backlog 401 arriving as tool output over transport 200:

--- a/src/auth/bearerAuthMiddleware.ts
+++ b/src/auth/bearerAuthMiddleware.ts
@@ -4,7 +4,7 @@
 import type { MiddlewareHandler } from 'hono';
 import type { AuthInfo } from '@modelcontextprotocol/server';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
-import { verifyBacklogToken } from './backlogOAuthClient.js';
+import { BacklogTokenError, verifyBacklogToken } from './backlogOAuthClient.js';
 import {
   hasBacklogAuthErrorBeenReported,
   runWithAccessToken,
@@ -78,7 +78,39 @@ export function createBearerAuthMiddleware(
         } satisfies AuthInfo;
         store.cacheVerification(mcpToken, authInfo, CACHE_TTL_MS);
       } catch (err) {
-        logger.warn({ err }, 'Bearer token verification failed');
+        // Only Backlog rejecting the token means this client should
+        // authenticate again. A Backlog outage answered with 401 would send
+        // every connected client through the whole authorization flow, and the
+        // token that flow produced would fail verification just the same.
+        const rejected =
+          err instanceof BacklogTokenError &&
+          (err.status === 401 || err.status === 403);
+
+        if (!rejected) {
+          logger.error(
+            { err },
+            'Could not verify the bearer token with Backlog'
+          );
+          c.header('Retry-After', '30');
+          return c.json(
+            {
+              error: 'temporarily_unavailable',
+              error_description: 'Could not verify the token with Backlog',
+            },
+            503
+          );
+        }
+
+        // A rejection here is the same fact `onAuthError` below acts on — the
+        // stored Backlog token is spent — so it gets the same treatment.
+        // Dropping the entry is what makes this recoverable: the client's next
+        // request fails the `getMcpToken` check above, and it reaches for its
+        // refresh token instead of replaying a credential that cannot work.
+        logger.warn(
+          { err, clientId: tokenEntry.clientId },
+          'Backlog rejected the stored access token during verification; revoking the MCP token'
+        );
+        store.revokeMcpToken(mcpToken);
         return unauthorized('Token verification failed');
       }
     }

--- a/src/auth/oauthRoutes.test.ts
+++ b/src/auth/oauthRoutes.test.ts
@@ -7,7 +7,13 @@ import { createOAuthRoutes } from './oauthRoutes.js';
 import { createTokenStore, type TokenStore } from './tokenStore.js';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 
-vi.mock('./backlogOAuthClient.js', () => ({
+// Only `BacklogTokenError` is borrowed from the real module: the routes branch
+// on `instanceof`, so a stand-in class would make the branch untestable. Every
+// function stays mocked, so nothing here can reach the network.
+vi.mock('./backlogOAuthClient.js', async (importOriginal) => ({
+  BacklogTokenError: (
+    await importOriginal<typeof import('./backlogOAuthClient.js')>()
+  ).BacklogTokenError,
   buildBacklogAuthorizationUrl: vi.fn(
     (_config: unknown, _redirect: unknown, state: string) =>
       `https://example.backlog.com/OAuth2AccessRequest.action?state=${state}`
@@ -817,6 +823,104 @@ describe('createOAuthRoutes', () => {
       const restored = store.consumeMcpRefreshToken('mcp-refresh-retry');
       expect(restored).toBeDefined();
       expect(restored!.backlogRefreshToken).toBe('bl-refresh');
+    });
+
+    // The bug this covers: every refresh failure answered 503, so a client
+    // whose grant Backlog had permanently discarded backed off and retried on
+    // a schedule forever, and never reached the re-authorization that was the
+    // only way out.
+    it('answers invalid_grant when Backlog says the grant is gone', async () => {
+      const { refreshBacklogToken, BacklogTokenError } =
+        await import('./backlogOAuthClient.js');
+      (refreshBacklogToken as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new BacklogTokenError(
+          'Backlog token refresh failed (400): {"error":"invalid_grant"}',
+          400,
+          'invalid_grant'
+        )
+      );
+
+      store.registerClient({
+        client_id: 'c1',
+        client_secret: 's1',
+        client_id_issued_at: 0,
+        client_secret_expires_at: 0,
+        redirect_uris: ['https://client.example.com/cb'],
+      });
+
+      store.storeMcpRefreshToken('mcp-refresh-revoked', {
+        backlogRefreshToken: 'bl-refresh',
+        clientId: 'c1',
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      });
+
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: 'c1',
+        client_secret: 's1',
+        refresh_token: 'mcp-refresh-revoked',
+      });
+
+      const res = await app.request('/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      });
+
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe('invalid_grant');
+
+      // Not restored: Backlog has disowned the token it holds, so keeping it
+      // until its TTL lapses would only hand the next attempt the same
+      // credential.
+      expect(
+        store.consumeMcpRefreshToken('mcp-refresh-revoked')
+      ).toBeUndefined();
+    });
+
+    // `invalid_client` rejects this server's own credentials, not the client's
+    // grant. Answering `invalid_grant` would send every client through an
+    // authorization flow that fails at the same wall.
+    it('treats a rejected client secret as transient and restores the token', async () => {
+      const { refreshBacklogToken, BacklogTokenError } =
+        await import('./backlogOAuthClient.js');
+      (refreshBacklogToken as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new BacklogTokenError(
+          'Backlog token refresh failed (401): {"error":"invalid_client"}',
+          401,
+          'invalid_client'
+        )
+      );
+
+      store.registerClient({
+        client_id: 'c1',
+        client_secret: 's1',
+        client_id_issued_at: 0,
+        client_secret_expires_at: 0,
+        redirect_uris: ['https://client.example.com/cb'],
+      });
+
+      store.storeMcpRefreshToken('mcp-refresh-401', {
+        backlogRefreshToken: 'bl-refresh',
+        clientId: 'c1',
+        expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+      });
+
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: 'c1',
+        client_secret: 's1',
+        refresh_token: 'mcp-refresh-401',
+      });
+
+      const res = await app.request('/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      });
+
+      expect(res.status).toBe(503);
+      expect(store.consumeMcpRefreshToken('mcp-refresh-401')).toBeDefined();
     });
 
     it('rejects unsupported grant_type', async () => {

--- a/src/auth/oauthRoutes.ts
+++ b/src/auth/oauthRoutes.ts
@@ -5,6 +5,7 @@ import { randomUUID, randomBytes, createHash } from 'node:crypto';
 import { Hono } from 'hono';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 import {
+  BacklogTokenError,
   buildBacklogAuthorizationUrl,
   exchangeBacklogCode,
   refreshBacklogToken,
@@ -577,6 +578,46 @@ export function createOAuthRoutes(
           refresh_token: mcpRefreshToken,
         });
       } catch (err) {
+        // `invalid_grant` is Backlog stating the grant is gone: revoked from
+        // the user's settings, or a refresh token it no longer recognises.
+        // That is the one answer that moves the client to a fresh
+        // authorization. Reported as 503 the same failure asks it to back off
+        // and retry a grant that can never come back, so it retries on a
+        // schedule forever. The consumed entry stays consumed in this branch:
+        // what it holds is a refresh token Backlog has already disowned, and
+        // keeping it until its TTL lapses only hands the next attempt the same
+        // dead credential.
+        //
+        // The code is read from the body rather than inferred from the status,
+        // because the status cannot separate the two rejections the token
+        // endpoint makes: `invalid_client` rejects *this server's* credentials,
+        // which is the operator's misconfiguration and not the client's grant,
+        // and re-authorizing would fail at the same wall. A bare 400 with no
+        // readable code is still treated as a dead grant — that is what the
+        // status means on this endpoint when nothing more specific is said.
+        //
+        // Everything else leaves the grant's fate unknown — unreachable, a
+        // timeout, a 5xx, a rejected client secret — so the entry goes back and
+        // the client is told to retry.
+        const grantIsGone =
+          err instanceof BacklogTokenError &&
+          (err.errorCode === 'invalid_grant' ||
+            (err.status === 400 && err.errorCode === undefined));
+
+        if (grantIsGone) {
+          logger.warn(
+            { err, clientId },
+            'Backlog no longer recognizes the refresh grant; the client must authorize again'
+          );
+          return c.json(
+            oauthError(
+              'invalid_grant',
+              'Backlog no longer recognizes this grant. A new authorization is required.'
+            ),
+            400
+          );
+        }
+
         logger.error({ err }, 'Failed to refresh Backlog token');
         store.storeMcpRefreshToken(refreshToken, refreshEntry);
         return c.json(


### PR DESCRIPTION
Closes #240.

On the HTTP transport with OAuth, `/token` answered `503 server_error` for every failed refresh, including the case where Backlog had stated the grant was permanently gone. The two answers ask the client for opposite behaviour, so a client whose grant had been revoked retried on a schedule forever and never reached the re-authorization that was the only way out.

This takes the issue's **Option 2**: carry the failure structurally out of `backlogOAuthClient`, then use it at both call sites that were guessing.

```
Backlog  -> 400 {"error":"invalid_grant"}   /token -> 400 invalid_grant   (was 503)
Backlog  -> 401 {"error":"invalid_client"}  /token -> 503 server_error    (unchanged)
Backlog  -> 5xx / unreachable / timeout     /token -> 503 server_error    (unchanged)
```

Three commits, each one independently green:

1. **`BacklogTokenError` carries the upstream failure.** `status`, absent when the request produced no response at all, plus `errorCode` — the `error` field of the body, where RFC 6749 §5.2 puts the reason.
2. **`/token` answers a dead grant with `invalid_grant`**, and stops restoring the consumed refresh entry in that branch.
3. **The bearer middleware tells an outage from a rejection** on the cache-miss path — the gap #218 explicitly left open.

### Why the reason is read from the body, not the status

The measured case is `400 invalid_grant`, so mapping `400` alone would fix the reported bug. But the token endpoint makes two different rejections and the status cannot separate them: `invalid_client` rejects **this server's** client credentials, which is the operator's misconfiguration and not the client's grant. Answering that with `invalid_grant` would send every connected client into an authorization flow that fails at the same wall.

So the rule is `errorCode === 'invalid_grant'`, with a bare `400` and no readable code still treated as a dead grant — that is what the status means on this endpoint when nothing more specific is said. This is the one deliberate departure from the issue's Option 1 wording, which suggested mapping `400`/`401` together.

### Behaviour changes a reviewer should weigh

- **`/token`, refresh grant:** an `invalid_grant` now returns `400` and does **not** restore the refresh entry. Every other failure keeps today's restore-and-`503`.
- **Bearer middleware, cache miss:** a Backlog outage now returns `503 temporarily_unavailable` with `Retry-After: 30` instead of `401`. Previously an outage cost every connected client its stored token and sent it through a full re-authorization whose result would have failed verification just the same.
- **Bearer middleware, cache miss:** a `401`/`403` from Backlog now also revokes the MCP token, so the client falls back to its refresh token. This is the payoff #240 named for Option 2, and it is the same treatment `onAuthError` already gives the same fact. It is isolated in its own commit if you would rather ship it separately.

`exchangeBacklogCode` is deliberately untouched: `/callback` answers with a redirect and nothing there branches on the failure, so giving it a status would add an unused field.

### Not included

MCP access tokens already issued against a dead grant are left alone. They fail on first use and `onAuthError` revokes them there; the store is keyed by token, so dropping them here would mean an index that does not exist yet.

### Verification

```
npx vitest run     # 96 files / 567 tests
npx tsc --noEmit
npm run lint       # oxlint --type-aware --type-check
npm run format     # oxfmt
```

Each of the three commits was checked out and verified on its own (562 / 564 / 567 tests, `tsc` clean at each).

New tests cover: the status and error code the client reports (including a non-JSON body and an unreachable Backlog); `/token` answering `invalid_grant` **and** leaving the entry consumed; `/token` treating `invalid_client` as transient **and** restoring it; the middleware returning `401` + revocation on a rejection, and `503` + `Retry-After` + no revocation on an outage or an error of unknown shape.

The module mocks in both test files borrow only the real `BacklogTokenError` class — the branches are `instanceof` checks, so a stand-in would make them untestable — while every function stays mocked, keeping the network unreachable from the tests.

### Follow-up in `backlog-remote-mcp-server`

That repo vendors `oauthRoutes.ts` and `backlogOAuthClient.ts`, and `src/lib.ts` exports no auth, so the fix cannot be shared as code today. Its state: the verify half already carries a status (as `BacklogTokenVerificationError`) and already answers `503`/`Retry-After`, but the refresh path is the unfixed original and the cache-miss revocation is absent. Worth a matching PR there, renaming the class to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
