### PR TITLE
Export the OAuth token client and its failure predicates

### DIFF
--- a/src/auth/backlogOAuthClient.test.ts
+++ b/src/auth/backlogOAuthClient.test.ts
@@ -5,6 +5,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   BacklogTokenError,
   buildBacklogAuthorizationUrl,
+  isGrantGone,
+  isTokenRejected,
   exchangeBacklogCode,
   refreshBacklogToken,
   verifyBacklogToken,
@@ -224,5 +226,47 @@ describe('verifyBacklogToken', () => {
 
     expect(err).toBeInstanceOf(BacklogTokenError);
     expect((err as BacklogTokenError).status).toBeUndefined();
+  });
+});
+
+// Exported from `src/lib.ts`, so a consumer hosting the same flow branches on
+// these instead of reimplementing the rules. Worth pinning directly: reading
+// `invalid_client` as a dead grant costs every client a pointless
+// authorization, and reading an outage as a rejection costs a live grant.
+describe('isGrantGone', () => {
+  it.each([
+    [
+      'an explicit invalid_grant',
+      new BacklogTokenError('m', 400, 'invalid_grant'),
+    ],
+    ['a bare 400 with no readable code', new BacklogTokenError('m', 400)],
+  ])('is true for %s', (_label, err) => {
+    expect(isGrantGone(err)).toBe(true);
+  });
+
+  it.each([
+    ['invalid_client', new BacklogTokenError('m', 401, 'invalid_client')],
+    ['a 5xx', new BacklogTokenError('m', 503)],
+    ['an unreachable Backlog', new BacklogTokenError('m')],
+    ['an error of another type', new Error('boom')],
+  ])('is false for %s', (_label, err) => {
+    expect(isGrantGone(err)).toBe(false);
+  });
+});
+
+describe('isTokenRejected', () => {
+  it.each([
+    ['a 401', new BacklogTokenError('m', 401)],
+    ['a 403', new BacklogTokenError('m', 403)],
+  ])('is true for %s', (_label, err) => {
+    expect(isTokenRejected(err)).toBe(true);
+  });
+
+  it.each([
+    ['a 500', new BacklogTokenError('m', 500)],
+    ['an unreachable Backlog', new BacklogTokenError('m')],
+    ['an error of another type', new Error('boom')],
+  ])('is false for %s', (_label, err) => {
+    expect(isTokenRejected(err)).toBe(false);
   });
 });

--- a/src/auth/backlogOAuthClient.ts
+++ b/src/auth/backlogOAuthClient.ts
@@ -58,6 +58,45 @@ function readOAuthErrorCode(body: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Whether the failure is Backlog stating the grant is gone.
+ *
+ * The one answer that means the client should stop retrying and start a fresh
+ * authorization. Everything else leaves the grant's fate unknown, and a client
+ * told to re-authorize on a transient failure throws away a grant that was
+ * still alive.
+ *
+ * Read from `errorCode` rather than inferred from the status, because the
+ * status cannot separate the two rejections a token endpoint makes:
+ * `invalid_client` rejects the *server's* own credentials, which is the
+ * operator's misconfiguration and not the client's grant — re-authorizing would
+ * fail at the same wall. A bare 400 with no readable code is still a dead
+ * grant: that is what the status means on this endpoint when nothing more
+ * specific is said.
+ */
+export function isGrantGone(err: unknown): boolean {
+  return (
+    err instanceof BacklogTokenError &&
+    (err.errorCode === 'invalid_grant' ||
+      (err.status === 400 && err.errorCode === undefined))
+  );
+}
+
+/**
+ * Whether Backlog rejected the credential, as opposed to failing to answer.
+ *
+ * Only a rejection means the caller should authenticate again. An outage
+ * treated as a rejection sends every connected client through the whole
+ * authorization flow, and the credential that flow produces fails the same way
+ * — after the client has already lost the one it had.
+ */
+export function isTokenRejected(err: unknown): boolean {
+  return (
+    err instanceof BacklogTokenError &&
+    (err.status === 401 || err.status === 403)
+  );
+}
+
 export function buildBacklogAuthorizationUrl(
   config: BacklogOAuthConfig,
   redirectUri: string,

--- a/src/auth/bearerAuthMiddleware.test.ts
+++ b/src/auth/bearerAuthMiddleware.test.ts
@@ -8,15 +8,14 @@ import { reportBacklogAuthError } from './backlogAuthContext.js';
 import { createTokenStore } from './tokenStore.js';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 
-// `BacklogTokenError` is the real class because the middleware branches on
-// `instanceof`; `verifyBacklogToken` is the only function this file needs, and
-// leaving the rest out keeps the network unreachable from here.
-vi.mock('./backlogOAuthClient.js', async (importOriginal) => ({
-  BacklogTokenError: (
-    await importOriginal<typeof import('./backlogOAuthClient.js')>()
-  ).BacklogTokenError,
-  verifyBacklogToken: vi.fn(),
-}));
+// The error class and `isTokenRejected` are the real ones, because they are
+// what the middleware branches on; `verifyBacklogToken` is the only function
+// this file needs, and leaving the rest out keeps the network unreachable.
+vi.mock('./backlogOAuthClient.js', async (importOriginal) => {
+  const { BacklogTokenError, isTokenRejected } =
+    await importOriginal<typeof import('./backlogOAuthClient.js')>();
+  return { BacklogTokenError, isTokenRejected, verifyBacklogToken: vi.fn() };
+});
 
 import { BacklogTokenError, verifyBacklogToken } from './backlogOAuthClient.js';
 

--- a/src/auth/bearerAuthMiddleware.ts
+++ b/src/auth/bearerAuthMiddleware.ts
@@ -4,7 +4,7 @@
 import type { MiddlewareHandler } from 'hono';
 import type { AuthInfo } from '@modelcontextprotocol/server';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
-import { BacklogTokenError, verifyBacklogToken } from './backlogOAuthClient.js';
+import { isTokenRejected, verifyBacklogToken } from './backlogOAuthClient.js';
 import {
   hasBacklogAuthErrorBeenReported,
   runWithAccessToken,
@@ -79,14 +79,9 @@ export function createBearerAuthMiddleware(
         store.cacheVerification(mcpToken, authInfo, CACHE_TTL_MS);
       } catch (err) {
         // Only Backlog rejecting the token means this client should
-        // authenticate again. A Backlog outage answered with 401 would send
-        // every connected client through the whole authorization flow, and the
-        // token that flow produced would fail verification just the same.
-        const rejected =
-          err instanceof BacklogTokenError &&
-          (err.status === 401 || err.status === 403);
-
-        if (!rejected) {
+        // authenticate again; `isTokenRejected` holds why the distinction
+        // matters.
+        if (!isTokenRejected(err)) {
           logger.error(
             { err },
             'Could not verify the bearer token with Backlog'

--- a/src/auth/oauthRoutes.test.ts
+++ b/src/auth/oauthRoutes.test.ts
@@ -7,30 +7,33 @@ import { createOAuthRoutes } from './oauthRoutes.js';
 import { createTokenStore, type TokenStore } from './tokenStore.js';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 
-// Only `BacklogTokenError` is borrowed from the real module: the routes branch
-// on `instanceof`, so a stand-in class would make the branch untestable. Every
-// function stays mocked, so nothing here can reach the network.
-vi.mock('./backlogOAuthClient.js', async (importOriginal) => ({
-  BacklogTokenError: (
-    await importOriginal<typeof import('./backlogOAuthClient.js')>()
-  ).BacklogTokenError,
-  buildBacklogAuthorizationUrl: vi.fn(
-    (_config: unknown, _redirect: unknown, state: string) =>
-      `https://example.backlog.com/OAuth2AccessRequest.action?state=${state}`
-  ),
-  exchangeBacklogCode: vi.fn().mockResolvedValue({
-    access_token: 'bl-access',
-    token_type: 'bearer',
-    expires_in: 3600,
-    refresh_token: 'bl-refresh',
-  }),
-  refreshBacklogToken: vi.fn().mockResolvedValue({
-    access_token: 'bl-new-access',
-    token_type: 'bearer',
-    expires_in: 3600,
-    refresh_token: 'bl-new-refresh',
-  }),
-}));
+// The error class and the failure predicates are borrowed from the real module:
+// they are what the routes branch on, so stand-ins would make the branch prove
+// nothing. Only the functions that reach the network are mocked.
+vi.mock('./backlogOAuthClient.js', async (importOriginal) => {
+  const { BacklogTokenError, isGrantGone } =
+    await importOriginal<typeof import('./backlogOAuthClient.js')>();
+  return {
+    BacklogTokenError,
+    isGrantGone,
+    buildBacklogAuthorizationUrl: vi.fn(
+      (_config: unknown, _redirect: unknown, state: string) =>
+        `https://example.backlog.com/OAuth2AccessRequest.action?state=${state}`
+    ),
+    exchangeBacklogCode: vi.fn().mockResolvedValue({
+      access_token: 'bl-access',
+      token_type: 'bearer',
+      expires_in: 3600,
+      refresh_token: 'bl-refresh',
+    }),
+    refreshBacklogToken: vi.fn().mockResolvedValue({
+      access_token: 'bl-new-access',
+      token_type: 'bearer',
+      expires_in: 3600,
+      refresh_token: 'bl-new-refresh',
+    }),
+  };
+});
 
 const config: BacklogOAuthConfig = {
   clientId: 'bl-client-id',

--- a/src/auth/oauthRoutes.ts
+++ b/src/auth/oauthRoutes.ts
@@ -5,9 +5,9 @@ import { randomUUID, randomBytes, createHash } from 'node:crypto';
 import { Hono } from 'hono';
 import type { BacklogOAuthConfig } from './backlogOAuthConfig.js';
 import {
-  BacklogTokenError,
   buildBacklogAuthorizationUrl,
   exchangeBacklogCode,
+  isGrantGone,
   refreshBacklogToken,
 } from './backlogOAuthClient.js';
 import type { TokenStore, OAuthClientInfo } from './tokenStore.js';
@@ -578,33 +578,16 @@ export function createOAuthRoutes(
           refresh_token: mcpRefreshToken,
         });
       } catch (err) {
-        // `invalid_grant` is Backlog stating the grant is gone: revoked from
-        // the user's settings, or a refresh token it no longer recognises.
-        // That is the one answer that moves the client to a fresh
-        // authorization. Reported as 503 the same failure asks it to back off
-        // and retry a grant that can never come back, so it retries on a
-        // schedule forever. The consumed entry stays consumed in this branch:
-        // what it holds is a refresh token Backlog has already disowned, and
-        // keeping it until its TTL lapses only hands the next attempt the same
-        // dead credential.
-        //
-        // The code is read from the body rather than inferred from the status,
-        // because the status cannot separate the two rejections the token
-        // endpoint makes: `invalid_client` rejects *this server's* credentials,
-        // which is the operator's misconfiguration and not the client's grant,
-        // and re-authorizing would fail at the same wall. A bare 400 with no
-        // readable code is still treated as a dead grant — that is what the
-        // status means on this endpoint when nothing more specific is said.
+        // A dead grant is the one failure the client can act on, and
+        // `isGrantGone` holds the reasoning for which failures those are. The
+        // consumed entry stays consumed here: what it holds is a refresh token
+        // Backlog has already disowned, and keeping it until its TTL lapses
+        // only hands the next attempt the same dead credential.
         //
         // Everything else leaves the grant's fate unknown — unreachable, a
         // timeout, a 5xx, a rejected client secret — so the entry goes back and
         // the client is told to retry.
-        const grantIsGone =
-          err instanceof BacklogTokenError &&
-          (err.errorCode === 'invalid_grant' ||
-            (err.status === 400 && err.errorCode === undefined));
-
-        if (grantIsGone) {
+        if (isGrantGone(err)) {
           logger.warn(
             { err, clientId },
             'Backlog no longer recognizes the refresh grant; the client must authorize again'

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -2,6 +2,8 @@ import * as lib from './lib';
 import { describe, it, expect } from 'vitest';
 import type { z } from 'zod';
 import type {
+  BacklogOAuthConfig,
+  BacklogTokenData,
   ComposeOptions,
   NativeContentToolDefinition,
   ErrorLike,
@@ -21,16 +23,24 @@ import type {
 describe('library entry point', () => {
   it('exports exactly the documented runtime surface', () => {
     expect(Object.keys(lib).sort()).toEqual([
+      'BacklogTokenError',
       'allTools',
       'backlogErrorHandler',
+      'buildBacklogAuthorizationUrl',
       'buildToolSchema',
       'composeNativeContentToolHandler',
       'composeToolHandler',
       'createDescriptionHelper',
+      'exchangeBacklogCode',
       'isErrorLike',
+      'isGrantGone',
+      'isTokenRejected',
+      'refreshBacklogToken',
+      'verifyBacklogToken',
     ]);
   });
 
+  // A class is a function too, so `BacklogTokenError` belongs in this check.
   it('exports every runtime symbol as a function', () => {
     for (const [name, value] of Object.entries(lib)) {
       expect(typeof value, name).toBe('function');
@@ -41,6 +51,8 @@ describe('library entry point', () => {
   // `typecheck:all` if any of them stops being exported.
   it('exports the documented types', () => {
     const types: [
+      BacklogOAuthConfig?,
+      BacklogTokenData?,
       ComposeOptions?,
       NativeContentToolDefinition<z.ZodRawShape>?,
       ErrorLike?,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -11,6 +11,12 @@
  * is the counter-example worth remembering: it reads the override file from disk,
  * so it belongs to the CLI and is deliberately absent below. Consumers on other
  * runtimes pass their own overrides to `createDescriptionHelper`.
+ *
+ * The OAuth exports are the token calls and the two predicates that say what a
+ * failure means. The routes and the middleware are absent: they are built
+ * against this package's synchronous `TokenStore` and Hono, so a consumer on
+ * its own storage cannot reuse them. The judgement travels, the plumbing does
+ * not.
  */
 
 export { allTools } from './tools/tools.js';
@@ -20,6 +26,15 @@ export { createDescriptionHelper } from './createDescriptionHelper.js';
 export { backlogErrorHandler } from './backlog/backlogErrorHandler.js';
 export { buildToolSchema } from './types/tool.js';
 export { isErrorLike } from './types/result.js';
+export {
+  BacklogTokenError,
+  buildBacklogAuthorizationUrl,
+  exchangeBacklogCode,
+  isGrantGone,
+  isTokenRejected,
+  refreshBacklogToken,
+  verifyBacklogToken,
+} from './auth/backlogOAuthClient.js';
 
 export type { ComposeOptions } from './handlers/builders/composeToolHandler.js';
 export type { ComposeNativeContentOptions } from './handlers/builders/composeNativeContentToolHandler.js';
@@ -30,3 +45,5 @@ export type {
 } from './types/tool.js';
 export type { Toolset, ToolsetGroup } from './types/toolsets.js';
 export type { ErrorLike, SafeResult } from './types/result.js';
+export type { BacklogOAuthConfig } from './auth/backlogOAuthConfig.js';
+export type { BacklogTokenData } from './auth/tokenStore.js';


### PR DESCRIPTION
Follow-up to #248, and the prerequisite for `backlog-remote-mcp-server` importing the fix instead of keeping a second copy.

```ts
export {
  BacklogTokenError,
  buildBacklogAuthorizationUrl, exchangeBacklogCode,
  isGrantGone, isTokenRejected,
  refreshBacklogToken, verifyBacklogToken,
} from './auth/backlogOAuthClient.js';
```

`isGrantGone` and `isTokenRejected` are new, extracted from the two call sites in #248 that made the judgement inline. Both now branch on them, so the exported rule is the one this package runs. A near-miss costs something either way: read `invalid_client` as a dead grant and every client gets a pointless authorization flow; read an outage as a rejection and a live grant is thrown away.

`createOAuthRoutes` and `createBearerAuthMiddleware` stay unexported — built against this package's synchronous `TokenStore` and Hono, so a consumer on async storage cannot reuse them.

**Diff:** +158 / -66; ~28 lines of implementation, the rest comments and tests. Deletions are the inline conditions the predicates replace. Two test files mock the client wholesale and need the predicates in the mock; `lib.test.ts` pins the export surface by design.

Alternative, if you prefer: export only `BacklogTokenError` and let each consumer write the conditions. A quarter of the diff, and gives up the part worth sharing.

Separately, `lib.ts`'s "no Node built-in" comment is already inaccurate on `main` (`node:async_hooks` via the two AsyncLocalStorage contexts) — filed as #250, not touched here. No broken consumer demonstrated; the client added here reaches none.

Verified: 578 tests, `tsc --noEmit`, `oxlint`, `oxfmt`, and the exports present in `build/lib.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
