### PR TITLE
lib.ts の Node 依存の契約を実態に合わせる

### DIFF
--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as lib from './lib';
 import { describe, it, expect } from 'vitest';
 import type { z } from 'zod';
@@ -70,4 +73,87 @@ describe('library entry point', () => {
     // It reads from disk, which would defeat the point of this entry point.
     expect(lib).not.toHaveProperty('loadDescriptionOverrides');
   });
+
+  // The header of `src/lib.ts` promises that nothing reachable from it needs a
+  // dependency a non-Node runtime lacks. Read as a guarantee, it gets used as
+  // one — #180 put `createTranslationHelper` on a subpath rather than let
+  // `cosmiconfig` and `node:os` into this graph — so the claim has to be
+  // checked rather than trusted. ESM evaluates a module's static imports
+  // whether or not the importing module uses the symbol, so one specifier
+  // anywhere in the graph is enough to break it for every consumer. Type-only
+  // imports are erased before it runs and dynamic ones are reached only when
+  // called, so neither counts.
+  it('reaches no unportable Node built-in through a static import', () => {
+    const srcDir = dirname(fileURLToPath(import.meta.url));
+    const seen = new Set<string>();
+    const offenders: string[] = [];
+
+    const walk = (file: string, trail: string[]): void => {
+      if (seen.has(file)) return;
+      seen.add(file);
+
+      const source = stripComments(readFileSync(file, 'utf8'));
+      for (const specifier of staticImportsOf(source)) {
+        if (specifier.startsWith('node:')) {
+          if (PORTABLE_BUILTINS.has(specifier)) continue;
+          offenders.push(
+            `${[...trail, relative(file)].join(' -> ')}: ${specifier}`
+          );
+          continue;
+        }
+        // Bare specifiers stop the walk: a package's own graph lives in
+        // `node_modules` and its `exports` may hand a different file to each
+        // runtime, so a source-level walk cannot answer for it. `cosmiconfig`
+        // — the other half of what #180 kept out — is therefore not covered
+        // here; only the `import` in this repository's own sources is.
+        if (!specifier.startsWith('.')) continue;
+        walk(resolveTs(file, specifier), [...trail, relative(file)]);
+      }
+    };
+
+    const relative = (file: string) => file.slice(srcDir.length + 1);
+    walk(resolve(srcDir, 'lib.ts'), []);
+
+    expect(offenders).toEqual([]);
+    // A resolution failure would empty the graph and pass silently, so pin that
+    // the walk actually reached the tool layer.
+    expect(seen.size).toBeGreaterThan(50);
+  });
 });
+
+/**
+ * Node built-ins the entry point is allowed to reach.
+ *
+ * The list is not "harmless built-ins" but "built-ins every runtime a consumer
+ * is on provides". `node:async_hooks` qualifies: Cloudflare Workers under
+ * `nodejs_compat`, Deno and Bun all have it, and the two `AsyncLocalStorage`
+ * request contexts need it on import. Adding to this list is a decision about
+ * which runtimes the package still supports, so it wants an argument in the
+ * commit rather than a quick edit to make a test pass.
+ */
+const PORTABLE_BUILTINS = new Set(['node:async_hooks']);
+
+/** Blanks out comments so a specifier mentioned in prose is not read as code. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[\t ]*\/\/.*$/gm, '');
+}
+
+/**
+ * The specifiers of the module's value-level static imports and re-exports.
+ *
+ * `import type` and `export type` are dropped: TypeScript erases them, so they
+ * never reach the runtime graph. Dynamic `import()` is not matched at all — it
+ * runs when the call runs, which is the whole point of using it here.
+ */
+function staticImportsOf(source: string): string[] {
+  const pattern =
+    /(?:^|\n)\s*(?:import|export)(?!\s+type\b)(?:[\s\S]*?from)?\s*['"]([^'"]+)['"]/g;
+  return [...source.matchAll(pattern)].map(([, specifier]) => specifier);
+}
+
+/** Maps the `.js` specifier the emitted ESM needs back to its `.ts` source. */
+function resolveTs(from: string, specifier: string): string {
+  return resolve(dirname(from), specifier.replace(/\.js$/, '.ts'));
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,10 +7,22 @@
  * This module exposes the pieces needed to build a server, and nothing that runs
  * on import.
  *
- * Nothing reachable from here may touch a Node built-in. `loadDescriptionOverrides`
- * is the counter-example worth remembering: it reads the override file from disk,
- * so it belongs to the CLI and is deliberately absent below. Consumers on other
- * runtimes pass their own overrides to `createDescriptionHelper`.
+ * The rule this entry point holds is narrower than "no Node built-ins": nothing
+ * reachable from here may touch a dependency that a non-Node runtime lacks.
+ * `loadDescriptionOverrides` is the counter-example worth remembering: it reads
+ * the override file from disk, so it belongs to the CLI and is deliberately
+ * absent below. Consumers on other runtimes pass their own overrides to
+ * `createDescriptionHelper`.
+ *
+ * `node:async_hooks` is the case that fixes the wording. Two `AsyncLocalStorage`
+ * modules — the OAuth request's access token, and the organization a
+ * multi-organization call is for — are reachable from `backlogErrorHandler` and
+ * from the two handler builders respectively, and ESM evaluates them on import
+ * whether or not the consumer uses the symbol. They stay: Cloudflare Workers
+ * (`nodejs_compat`), Deno and Bun all provide `async_hooks`, and every consumer
+ * on record runs on one of those or on Node. `lib.test.ts` walks the import
+ * graph and holds exactly this line — a built-in outside the allowed set fails
+ * there rather than in a consumer's build.
  *
  * The OAuth exports are the token calls and the two predicates that say what a
  * failure means. The routes and the middleware are absent: they are built


### PR DESCRIPTION
`src/lib.ts` は「この入口から辿れるものは Node 組み込みを触らない」と述べているが、`AsyncLocalStorage` を使う 2 モジュールが到達可能（#250）。

| export | 経路 |
|---|---|
| `backlogErrorHandler` | `auth/backlogAuthContext.ts` → `node:async_hooks` |
| `composeToolHandler` / `composeNativeContentToolHandler` | `utils/backlogOrganizationContext.ts` → `node:async_hooks` |

## 変更

- 文言を #180 の粒度に戻した。あの PR が排除したのは Node 組み込み一般ではなく `cosmiconfig` と `node:os`、つまり Workers に存在しない依存。`node:async_hooks` は Workers（`nodejs_compat`）・Deno・Bun にあるので線の内側。
- `lib.test.ts` がインポートグラフを歩き、許可集合 `PORTABLE_BUILTINS` の外にある `node:` 指定子で落ちる。型のみ import は消えるので数えず、動的 import も数えない。

## 案1（ALS 遅延化）を採らなかった理由

`composeToolHandler` が全ハンドラを `wrapWithOrganizationContext` で無条件に包むため（`composeToolHandler.ts:63`）、落ちる場所が import 時から初回ツール呼び出し時に移るだけ。真にするには organization を `backlogClientRegistry`（`:78`, `:194`）まで引数で貫通させることになる。

## 既知の穴

bare 指定子で walk は止まる（`node_modules` の `exports` はランタイムごとに別ファイルを返し得る）。`cosmiconfig` は覆えていない。

## 検証

579 tests / 96 files pass、lint・format clean。`types/result.ts` に `node:os` を注入すると経路付きで落ちることを確認。

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
