### PR TITLE
docs: 実態に合わせて lib.ts の Node 依存の契約を書き直す

### DIFF
--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import * as lib from './lib';
 import { describe, it, expect } from 'vitest';
 import type { z } from 'zod';
@@ -70,4 +73,75 @@ describe('library entry point', () => {
     // It reads from disk, which would defeat the point of this entry point.
     expect(lib).not.toHaveProperty('loadDescriptionOverrides');
   });
+
+  // The header of `src/lib.ts` reads as a guarantee and gets used as one — #180
+  // put `createTranslationHelper` on a subpath to keep `cosmiconfig` and
+  // `node:os` out of this graph — so it is checked rather than trusted. ESM
+  // evaluates static imports whether or not the symbol is used, so one
+  // specifier anywhere in the graph breaks it for every consumer.
+  it('reaches no unportable Node built-in through a static import', () => {
+    const srcDir = dirname(fileURLToPath(import.meta.url));
+    const seen = new Set<string>();
+    const offenders: string[] = [];
+
+    const walk = (file: string, trail: string[]): void => {
+      if (seen.has(file)) return;
+      seen.add(file);
+
+      const source = stripComments(readFileSync(file, 'utf8'));
+      for (const specifier of staticImportsOf(source)) {
+        if (specifier.startsWith('node:')) {
+          if (PORTABLE_BUILTINS.has(specifier)) continue;
+          offenders.push(
+            `${[...trail, relative(file)].join(' -> ')}: ${specifier}`
+          );
+          continue;
+        }
+        // Bare specifiers stop the walk: `exports` may hand a different file
+        // to each runtime, so a source-level walk cannot answer for a package.
+        // `cosmiconfig` is therefore not covered here.
+        if (!specifier.startsWith('.')) continue;
+        walk(resolveTs(file, specifier), [...trail, relative(file)]);
+      }
+    };
+
+    const relative = (file: string) => file.slice(srcDir.length + 1);
+    walk(resolve(srcDir, 'lib.ts'), []);
+
+    expect(offenders).toEqual([]);
+    // A resolution failure would empty the graph and pass silently, so pin that
+    // the walk actually reached the tool layer.
+    expect(seen.size).toBeGreaterThan(50);
+  });
 });
+
+/**
+ * Not "harmless built-ins" but "built-ins every runtime a consumer is on has".
+ * `async_hooks` is on Workers (`nodejs_compat`), Deno and Bun, and the two
+ * `AsyncLocalStorage` request contexts need it on import. Adding to this set
+ * narrows which runtimes the package supports — argue for it in the commit.
+ */
+const PORTABLE_BUILTINS = new Set(['node:async_hooks']);
+
+/** Blanks out comments so a specifier mentioned in prose is not read as code. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[\t ]*\/\/.*$/gm, '');
+}
+
+/**
+ * Value-level static imports and re-exports. `import type` is dropped because
+ * TypeScript erases it; dynamic `import()` is not matched, since it runs only
+ * when called.
+ */
+function staticImportsOf(source: string): string[] {
+  const pattern =
+    /(?:^|\n)\s*(?:import|export)(?!\s+type\b)(?:[\s\S]*?from)?\s*['"]([^'"]+)['"]/g;
+  return [...source.matchAll(pattern)].map(([, specifier]) => specifier);
+}
+
+/** Maps the `.js` specifier the emitted ESM needs back to its `.ts` source. */
+function resolveTs(from: string, specifier: string): string {
+  return resolve(dirname(from), specifier.replace(/\.js$/, '.ts'));
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,10 +7,12 @@
  * This module exposes the pieces needed to build a server, and nothing that runs
  * on import.
  *
- * Nothing reachable from here may touch a Node built-in. `loadDescriptionOverrides`
- * is the counter-example worth remembering: it reads the override file from disk,
- * so it belongs to the CLI and is deliberately absent below. Consumers on other
- * runtimes pass their own overrides to `createDescriptionHelper`.
+ * Nothing reachable from here may need a dependency a non-Node runtime lacks —
+ * not "no Node built-ins": the two `AsyncLocalStorage` request contexts are
+ * reachable, and `node:async_hooks` exists on Workers, Deno and Bun.
+ * `loadDescriptionOverrides` reads from disk, so it belongs to the CLI and is
+ * absent below; other runtimes pass their own overrides to
+ * `createDescriptionHelper`. `lib.test.ts` walks the graph and holds the line.
  *
  * The OAuth exports are the token calls and the two predicates that say what a
  * failure means. The routes and the middleware are absent: they are built


### PR DESCRIPTION
`src/lib.ts` は「この入口から辿れるものは Node 組み込みを触らない」と述べ
ていたが、`AsyncLocalStorage` を使う 2 モジュールが到達可能だった。
`backlogErrorHandler` は `auth/backlogAuthContext.ts` 経由、2 つのハンドラ ビルダは `utils/backlogOrganizationContext.ts` 経由で `node:async_hooks` に届く。

文言を #180 の粒度に戻した。あの PR が排除したのは Node 組み込み一般では
なく `cosmiconfig` と `node:os`、つまり Workers に存在しない依存だった。 `node:async_hooks` は Workers（`nodejs_compat`）・Deno・Bun にあるので線の 内側にある。

ALS の遅延化は採らなかった。`composeToolHandler` が全ハンドラを
`wrapWithOrganizationContext` で無条件に包むため、落ちる場所が import 時か ら初回ツール呼び出し時に移るだけである。

緩めた線は `lib.test.ts` が押さえる。インポートグラフを歩き、許可集合の外
にある `node:` 指定子で落ちる。bare 指定子で walk は止まるため
`cosmiconfig` は覆えていない。

Closes #250