### PR TITLE
lib.ts と lib.test.ts のコメントを削る

### DIFF
--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -74,15 +74,11 @@ describe('library entry point', () => {
     expect(lib).not.toHaveProperty('loadDescriptionOverrides');
   });
 
-  // The header of `src/lib.ts` promises that nothing reachable from it needs a
-  // dependency a non-Node runtime lacks. Read as a guarantee, it gets used as
-  // one — #180 put `createTranslationHelper` on a subpath rather than let
-  // `cosmiconfig` and `node:os` into this graph — so the claim has to be
-  // checked rather than trusted. ESM evaluates a module's static imports
-  // whether or not the importing module uses the symbol, so one specifier
-  // anywhere in the graph is enough to break it for every consumer. Type-only
-  // imports are erased before it runs and dynamic ones are reached only when
-  // called, so neither counts.
+  // The header of `src/lib.ts` reads as a guarantee and gets used as one — #180
+  // put `createTranslationHelper` on a subpath to keep `cosmiconfig` and
+  // `node:os` out of this graph — so it is checked rather than trusted. ESM
+  // evaluates static imports whether or not the symbol is used, so one
+  // specifier anywhere in the graph breaks it for every consumer.
   it('reaches no unportable Node built-in through a static import', () => {
     const srcDir = dirname(fileURLToPath(import.meta.url));
     const seen = new Set<string>();
@@ -101,11 +97,9 @@ describe('library entry point', () => {
           );
           continue;
         }
-        // Bare specifiers stop the walk: a package's own graph lives in
-        // `node_modules` and its `exports` may hand a different file to each
-        // runtime, so a source-level walk cannot answer for it. `cosmiconfig`
-        // — the other half of what #180 kept out — is therefore not covered
-        // here; only the `import` in this repository's own sources is.
+        // Bare specifiers stop the walk: `exports` may hand a different file
+        // to each runtime, so a source-level walk cannot answer for a package.
+        // `cosmiconfig` is therefore not covered here.
         if (!specifier.startsWith('.')) continue;
         walk(resolveTs(file, specifier), [...trail, relative(file)]);
       }
@@ -122,14 +116,10 @@ describe('library entry point', () => {
 });
 
 /**
- * Node built-ins the entry point is allowed to reach.
- *
- * The list is not "harmless built-ins" but "built-ins every runtime a consumer
- * is on provides". `node:async_hooks` qualifies: Cloudflare Workers under
- * `nodejs_compat`, Deno and Bun all have it, and the two `AsyncLocalStorage`
- * request contexts need it on import. Adding to this list is a decision about
- * which runtimes the package still supports, so it wants an argument in the
- * commit rather than a quick edit to make a test pass.
+ * Not "harmless built-ins" but "built-ins every runtime a consumer is on has".
+ * `async_hooks` is on Workers (`nodejs_compat`), Deno and Bun, and the two
+ * `AsyncLocalStorage` request contexts need it on import. Adding to this set
+ * narrows which runtimes the package supports — argue for it in the commit.
  */
 const PORTABLE_BUILTINS = new Set(['node:async_hooks']);
 
@@ -141,11 +131,9 @@ function stripComments(source: string): string {
 }
 
 /**
- * The specifiers of the module's value-level static imports and re-exports.
- *
- * `import type` and `export type` are dropped: TypeScript erases them, so they
- * never reach the runtime graph. Dynamic `import()` is not matched at all — it
- * runs when the call runs, which is the whole point of using it here.
+ * Value-level static imports and re-exports. `import type` is dropped because
+ * TypeScript erases it; dynamic `import()` is not matched, since it runs only
+ * when called.
  */
 function staticImportsOf(source: string): string[] {
   const pattern =

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,22 +7,12 @@
  * This module exposes the pieces needed to build a server, and nothing that runs
  * on import.
  *
- * The rule this entry point holds is narrower than "no Node built-ins": nothing
- * reachable from here may touch a dependency that a non-Node runtime lacks.
- * `loadDescriptionOverrides` is the counter-example worth remembering: it reads
- * the override file from disk, so it belongs to the CLI and is deliberately
- * absent below. Consumers on other runtimes pass their own overrides to
- * `createDescriptionHelper`.
- *
- * `node:async_hooks` is the case that fixes the wording. Two `AsyncLocalStorage`
- * modules — the OAuth request's access token, and the organization a
- * multi-organization call is for — are reachable from `backlogErrorHandler` and
- * from the two handler builders respectively, and ESM evaluates them on import
- * whether or not the consumer uses the symbol. They stay: Cloudflare Workers
- * (`nodejs_compat`), Deno and Bun all provide `async_hooks`, and every consumer
- * on record runs on one of those or on Node. `lib.test.ts` walks the import
- * graph and holds exactly this line — a built-in outside the allowed set fails
- * there rather than in a consumer's build.
+ * Nothing reachable from here may need a dependency a non-Node runtime lacks —
+ * not "no Node built-ins": the two `AsyncLocalStorage` request contexts are
+ * reachable, and `node:async_hooks` exists on Workers, Deno and Bun.
+ * `loadDescriptionOverrides` reads from disk, so it belongs to the CLI and is
+ * absent below; other runtimes pass their own overrides to
+ * `createDescriptionHelper`. `lib.test.ts` walks the graph and holds the line.
  *
  * The OAuth exports are the token calls and the two predicates that say what a
  * failure means. The routes and the middleware are absent: they are built


### PR DESCRIPTION
#251 のコメントが冗長だったので削る。`lib.ts` のヘッダは 17 行 → 6 行、`lib.test.ts` も約半分。制約とその理由だけを残し、経緯・却下した案・コードの言い直しを落とした。

挙動もテスト内容も変わらない（579 tests / 96 files pass、lint・format clean）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
